### PR TITLE
[TrashMob] Fix PartnerTypees Typo

### DIFF
--- a/TrashMob/client-app/src/store/partnerTypeHelper.tsx
+++ b/TrashMob/client-app/src/store/partnerTypeHelper.tsx
@@ -3,7 +3,7 @@ import { getDefaultHeaders } from "./AuthStore";
 
 export function getPartnerType(partnerTypeList: PartnerTypeData[], partnerTypeId: any): string {
     if (partnerTypeList === null || partnerTypeList.length === 0) {
-        partnerTypeList = getPartnerTypees();
+        partnerTypeList = getPartnerTypes();
     }
 
     var partnerType = partnerTypeList.find(et => et.id === partnerTypeId)
@@ -12,10 +12,10 @@ export function getPartnerType(partnerTypeList: PartnerTypeData[], partnerTypeId
     return "Unknown";
 }
 
-function getPartnerTypees(): PartnerTypeData[] {
+function getPartnerTypes(): PartnerTypeData[] {
     const headers = getDefaultHeaders('GET');
 
-    fetch('/api/partnerTypees', {
+    fetch('/api/partnerTypes', {
         method: 'GET',
         headers: headers
     })


### PR DESCRIPTION
### What
Fixed typo from Website to Api

### Why
`getPartnerType` method in `partnerTypeHelper.tsx` was querying an endpoint that doesn't exist.

### Note
@joebeernink - Still learning how this is used, and how to run locally so not sure what the impact of this now (at least in theory) returning data would be. 