### PR TITLE
Remove hover from disabled buttons

### DIFF
--- a/TrashMob/client-app/src/App.scss
+++ b/TrashMob/client-app/src/App.scss
@@ -402,7 +402,7 @@ button,
 }
 
 .dropdown>a:hover,
-button:hover {
+button:hover:enabled {
   background-color: #546900 !important;
 }
 

--- a/TrashMob/client-app/src/custom.css
+++ b/TrashMob/client-app/src/custom.css
@@ -226,7 +226,7 @@ hr.rounded {
   background-color: unset !important;
 }
 
-.btn-outline:hover {
+.btn-outline:hover:enabled {
   background-color: #96ba00 !important;
   color: #fff !important;
   border: none;


### PR DESCRIPTION
- When a button is disabled, such as the IsSaveEnabled toggle being off in the EditEvent component, remove the hover effect from buttons
- Disables both buttons from the EditEvent component until all required fields are filled

- Without filling out the location and hovering over Save button:
![image](https://github.com/TrashMob-eco/TrashMob/assets/97642703/467c754c-b650-47fd-b6d2-5e367155b09c)

- After filling out the location (can hover over both save buttons and submit):
![image](https://github.com/TrashMob-eco/TrashMob/assets/97642703/3ec45049-b049-4c52-bab2-eeb75fde6e81)
