### PR TITLE
Added event status column to Admin events page

### DIFF
--- a/TrashMob/client-app/src/components/Admin/AdminEvents.tsx
+++ b/TrashMob/client-app/src/components/Admin/AdminEvents.tsx
@@ -17,6 +17,13 @@ export const AdminEvents: React.FC<AdminEventsPropsType> = (props) => {
     const [eventList, setEventList] = React.useState<EventData[]>([]);
     const [isEventDataLoaded, setIsEventDataLoaded] = React.useState<boolean>(false);
 
+    const eventStatus = {
+        1 : "Active",
+        2 : "Full",
+        3 : "Canceled",
+        4 : "Complete"
+    }
+
     React.useEffect(() => {
 
         if (props.isUserLoaded) {
@@ -69,6 +76,7 @@ export const AdminEvents: React.FC<AdminEventsPropsType> = (props) => {
                     <thead>
                         <tr>
                             <th>Name</th>
+                            <th>Status</th>
                             <th>Date</th>
                             <th>City</th>
                             <th>Region</th>
@@ -82,6 +90,7 @@ export const AdminEvents: React.FC<AdminEventsPropsType> = (props) => {
                             return (
                                 <tr key={mobEvent.id.toString()}>
                                     <td>{mobEvent.name}</td>
+                                    <td>{eventStatus[mobEvent.eventStatusId]}</td>
                                     <td>{new Date(mobEvent.eventDate).toLocaleString()}</td>
                                     <td>{mobEvent.city}</td>
                                     <td>{mobEvent.region}</td>


### PR DESCRIPTION
Added status col to the admin events
![image](https://github.com/TrashMob-eco/TrashMob/assets/97642703/14c73780-d363-4387-8844-be88b31bc9e6)

Created test event to cancel-
![image](https://github.com/TrashMob-eco/TrashMob/assets/97642703/d63d0108-14a0-41c5-9199-991f13a12b8f)

After deleting in the Admin page
![image](https://github.com/TrashMob-eco/TrashMob/assets/97642703/bb573475-4060-4dcb-b118-25acc5be8588)

Could also be interesting to have an option to sort / order by event status :)