### PR TITLE
Fix mobile deployments

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -18,6 +18,9 @@ on:
             bundle_id:
                 required: true
                 type: string
+            version:
+                required: false
+                type: string
         secrets:
             android_keystore:
                 required: true
@@ -48,6 +51,15 @@ jobs:
             $content = Get-Content TrashMobMobile/TrashMobMobile.csproj -Raw
 
             $newContent = $content -replace '<ApplicationVersion>.*</ApplicationVersion>', "<ApplicationVersion>$buildNumber</ApplicationVersion>"
+
+            Set-Content TrashMobMobile/TrashMobMobile.csproj -Value $newContent
+
+        - name: Update version
+          if: inputs.version != null
+          run: |
+            $content = Get-Content TrashMobMobile/TrashMobMobile.csproj -Raw
+
+            $newContent = $content -replace '<ApplicationDisplayVersion>.*</ApplicationDisplayVersion>', "<ApplicationDisplayVersion>${{ inputs.version }}</ApplicationDisplayVersion>"
 
             Set-Content TrashMobMobile/TrashMobMobile.csproj -Value $newContent
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -21,6 +21,9 @@ on:
             ios_provisioning_profile_type:
                 required: true
                 type: string
+            version:
+                required: false
+                type: string
         secrets:
             ios_signing_certificate:
                 required: true
@@ -48,6 +51,10 @@ jobs:
 
         - name: Update Build Number
           run: sed -i '' "s|<ApplicationVersion>.*</ApplicationVersion>|<ApplicationVersion>${{ inputs.build_number }}</ApplicationVersion>|g" TrashMobMobile/TrashMobMobile.csproj
+
+        - name: Update Version Number
+          if: inputs.version != null
+          run: sed -i '' "s|<ApplicationDisplayVersion>.*</ApplicationDisplayVersion>|<Version>${{ inputs.version }}</Version>|g" TrashMobMobile/TrashMobMobile.csproj
 
         - name: Update Bundle ID
           run: sed -i '' "s|<ApplicationId>.*</ApplicationId>|<ApplicationId>${{ inputs.bundle_id }}</ApplicationId>|g" TrashMobMobile/TrashMobMobile.csproj

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -4,15 +4,19 @@
 name: TrashMobMobileApp - Prod
 
 on:
-  push:
-    branches:
-      - release
-    paths:
-      - '.github/**'
-      - 'TrashMob.Models/**'
-      - 'TrashMobMobile/**'
+  # push:
+  #   branches:
+  #     - release
+  #   paths:
+  #     - '.github/**'
+  #     - 'TrashMob.Models/**'
+  #     - 'TrashMobMobile/**'
 
   workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        required: true
 
 env:
   DOTNET_VERSION: '8.0.x'  # set this to the dotnet version to use

--- a/TrashMobMobile/Platforms/iOS/Info.plist
+++ b/TrashMobMobile/Platforms/iOS/Info.plist
@@ -37,7 +37,7 @@
         <string>Auth</string>
         <key>CFBundleURLSchemes</key>
         <array>
-          <string>eco.trashmob.trashmobmobile://auth</string>
+          <string>eco.trashmob.trashmobmobile</string>
         </array>
       </dict>
     </array>

--- a/TrashMobMobile/TrashMobMobile.csproj
+++ b/TrashMobMobile/TrashMobMobile.csproj
@@ -27,7 +27,7 @@
 		<ApplicationId>eco.trashmob.trashmobmobileapp</ApplicationId>
 
 		<!-- Versions -->
-		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+		<ApplicationDisplayVersion>1.0.2</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>


### PR DESCRIPTION
* Fixes the URL scheme for iOS
* Updates the version number
* Updates the mobile release workflow to be manually triggered, and require a version number

PR is good to go but Google deployments will still fail while we are porting the app from @joebeernink 's account to the TrashMob account