### PR TITLE
Fix release version issues

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -43,16 +43,11 @@ jobs:
         steps:
         - uses: actions/checkout@v3
 
-        - name: Use build number
-          run: |
-            $buildNumber=${{ inputs.build_number }}
-            echo "Build Number: $buildNumber"
-
         - name: Update Build Number
           run: |
             $content = Get-Content TrashMobMobile/TrashMobMobile.csproj -Raw
 
-            $newContent = $content -replace '<ApplicationVersion>.*</ApplicationVersion>', "<ApplicationVersion>$buildNumber</ApplicationVersion>"
+            $newContent = $content -replace '<ApplicationVersion>.*</ApplicationVersion>', "<ApplicationVersion>${{ inputs.build_number }}</ApplicationVersion>"
 
             Set-Content TrashMobMobile/TrashMobMobile.csproj -Value $newContent
 

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -91,6 +91,7 @@ jobs:
       build_number: ${{ needs.generate-build-number.outputs.buildNumber }}
       dotnet_version: ${{ needs.exposeEnvironmentVariables.outputs.dotnet_version }}
       bundle_id: ${{ needs.exposeEnvironmentVariables.outputs.android_bundle_id }}
+      version: ${{ github.event.inputs.version }}
     secrets:
       android_keystore: ${{ secrets.ANDROID_KEYSTORE }}
       android_keystore_password: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -108,6 +109,7 @@ jobs:
       bundle_id: ${{ needs.exposeEnvironmentVariables.outputs.ios_bundle_id }}
       dotnet_version: ${{ needs.exposeEnvironmentVariables.outputs.dotnet_version }}
       ios_provisioning_profile_type: ${{ needs.exposeEnvironmentVariables.outputs.ios_provisioning_profile_type }}
+      version: ${{ github.event.inputs.version }}
     secrets:
       ios_signing_certificate: ${{ secrets.IOS_CERTIFICATES_P12 }}
       ios_signing_certificate_password: ${{ secrets.IOS_CERTIFICATES_P12_PASSWORD }}


### PR DESCRIPTION
This PR does a couple of things:

* Uses the build number input directly in the Android build. Previously was setting it as a PowerShell variable, which won't persist between steps.
* Passes the version number from the Release workflow to the build workflow.

Build number is what's currently failing in Google Play. Version number is optional - if it's not provided to the Build workflow the step that replaces it is skipped. This is the "display version", meaning this is the version you show to user's when you want to release a new build (e.g. `1.0.2` -> `1.0.3`). The build number is used solely to distinguish the build within the App Store or Play Store.