### PR TITLE
[M] Added Datatype Binding to all XAML Pages in the project

### DIFF
--- a/TrashMobMobile/Pages/CancelEventPage.xaml
+++ b/TrashMobMobile/Pages/CancelEventPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:CancelEventViewModel"
              x:Class="TrashMobMobile.Pages.CancelEventPage"
              Title="Cancel Event">
     <ScrollView>
@@ -19,14 +21,14 @@
                     <VerticalStackLayout Grid.Row="1">
                         <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
                         <Border Style="{x:StaticResource RoundBorder}">
-                            <Label Text="{Binding EventViewModel.EventViewModel.DisplayDate}" FontSize="Small" />
+                            <Label Text="{Binding EventViewModel.DisplayDate}" FontSize="Small" />
                         </Border>
                     </VerticalStackLayout>
 
                     <VerticalStackLayout Grid.Row="2">
                         <Label Text="Event Date" Style="{StaticResource FieldLabel}" />
                         <Border Style="{x:StaticResource RoundBorder}">
-                            <Label Text="{Binding EventViewModel.EventViewModel.DisplayTime}" FontSize="Small" />
+                            <Label Text="{Binding EventViewModel.DisplayTime}" FontSize="Small" />
                         </Border>
                     </VerticalStackLayout>
 

--- a/TrashMobMobile/Pages/CreateEventPage.xaml
+++ b/TrashMobMobile/Pages/CreateEventPage.xaml
@@ -5,6 +5,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:CreateEventViewModel"
              Title="Create Event">
     <ScrollView>
         <Grid>
@@ -54,7 +56,7 @@
                         <Label Text="Duration Hours" Style="{StaticResource FieldLabel}" />
 
                         <Entry Keyboard="Numeric"
-                               Text="{Binding EventVieWModel.DurationHours}">
+                               Text="{Binding EventViewModel.DurationHours}">
                             <Entry.Behaviors>
                                 <toolkit:NumericValidationBehavior Flags="ValidateOnValueChanged"
                                                                    x:Name="durationHoursValidator" MinimumValue="1"
@@ -133,7 +135,7 @@
                               ItemsSource="{Binding Events}"
                               MapClicked="OnMapClicked">
                         <maps:Map.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:EventViewModel">
                                 <maps:Pin Address="{Binding Address.StreetAddress}"
                                           Label="{Binding Name}"
                                           Location="{Binding Address.Location}" />

--- a/TrashMobMobile/Pages/CreateLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/CreateLitterReportPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage x:Class="TrashMobMobile.Pages.CreateLitterReportPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:CreateLitterReportViewModel"
              Title="Submit Litter Report">
     <ScrollView>
         <Grid>
@@ -48,7 +50,7 @@
                                     ItemsSource="{Binding LitterImageViewModels}"
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                 <Border Style="{StaticResource RoundBorder}">
                                     <Grid ColumnDefinitions="Auto, *, Auto">
                                         <Image Grid.Column="0"

--- a/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/CreatePickupLocationPage.xaml
@@ -4,6 +4,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:CreatePickupLocationViewModel"
              x:Class="TrashMobMobile.Pages.CreatePickupLocationPage"
              Title="Create Pickup Location">
     <ScrollView>
@@ -44,7 +46,7 @@
 
                 <maps:Map x:Name="pickupLocationMap" ItemsSource="{Binding PickupLocations}">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
                             <maps:Pin Location="{Binding Address.Location}"
                                       Address="{Binding Address.StreetAddress}"
                                       Label="{Binding Name}" />

--- a/TrashMobMobile/Pages/EditEventPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPage.xaml
@@ -4,6 +4,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:EditEventViewModel"
              x:Class="TrashMobMobile.Pages.EditEventPage"
              Title="Edit Event">
     <ScrollView>
@@ -127,7 +129,7 @@
                 <maps:Map x:Name="eventLocationMap" ItemsSource="{Binding Events}" IsShowingUser="True"
                           MapClicked="OnMapClicked">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
                             <maps:Pin Location="{Binding Address.Location}"
                                       Address="{Binding Address.StreetAddress}"
                                       Label="{Binding Name}" />
@@ -208,14 +210,15 @@
                         </Button.Triggers>
                     </Button>
 
-                    <Button Margin="10"
-                            Grid.Row="0"
-                            Grid.Column="2"
-                            Grid.ColumnSpan="2"
-                            Command="{Binding ManageEventPartnersCommand}"
-                            IsEnabled="{Binding IsManageEventPartnersEnabled}"
-                            IsVisible="{Binding IsManageEventPartnersEnabled}"
-                            Text="Manage Partners" />
+                    <!-- TODO find the attribute to bind -->
+                    <!-- <Button Margin="10" -->
+                    <!--         Grid.Row="0" -->
+                    <!--         Grid.Column="2" -->
+                    <!--         Grid.ColumnSpan="2" -->
+                    <!--         Command="{Binding ManageEventPartnersCommand}" -->
+                    <!--         IsEnabled="{Binding IsManageEventPartnersEnabled}" -->
+                    <!--         IsVisible="{Binding IsManageEventPartnersEnabled}" -->
+                    <!--         Text="Manage Partners" /> -->
                 </Grid>
 
                 <Label

--- a/TrashMobMobile/Pages/EditEventPartnerLocationServicesPage.xaml
+++ b/TrashMobMobile/Pages/EditEventPartnerLocationServicesPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="TrashMobMobile.Pages.EditEventPartnerLocationServicesPage"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:EditEventPartnerLocationServicesViewModel"
              Title="Partner Services">
     <ScrollView>
         <Grid>
@@ -20,7 +22,7 @@
                                     ItemsSource="{Binding EventPartnerLocationServices}"
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:EventPartnerLocationServiceViewModel">
                                 <Border Style="{StaticResource RoundBorder}">
                                     <Grid ColumnDefinitions="1*, 1*, 1*, 1*"
                                           RowDefinitions="Auto"
@@ -28,7 +30,8 @@
                                         <Label Text="{Binding PartnerLocationName}" Grid.Column="0" FontSize="Micro" />
                                         <Label Text="{Binding ServiceName}" Grid.Column="1" FontSize="Micro" />
                                         <Label Text="{Binding ServiceStatus}" Grid.Column="2" FontSize="Micro" />
-                                        <Label Text="{Binding Notes}" Grid.Column="3" FontSize="Micro" />
+                                        <!-- TODO find the attribute to bind -->
+                                        <!-- <Label Text="{Binding Notes}" Grid.Column="3" FontSize="Micro" /> -->
                                         <Button Text="Request Service" Command="{Binding RequestServiceCommand}"
                                                 IsEnabled="{Binding CanRequestService}"
                                                 IsVisible="{Binding CanRequestService}" Grid.Column="4"

--- a/TrashMobMobile/Pages/EditEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/EditEventSummaryPage.xaml
@@ -2,6 +2,8 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:EditEventSummaryViewModel"
              x:Class="TrashMobMobile.Pages.EditEventSummaryPage"
              Title="Event Summary">
     <ScrollView>

--- a/TrashMobMobile/Pages/EditLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/EditLitterReportPage.xaml
@@ -3,9 +3,10 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:EditLitterReportViewModel"
              x:Class="TrashMobMobile.Pages.EditLitterReportPage"
              Title="Edit Litter Report">
-
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
@@ -60,7 +61,7 @@
                     <maps:Map Grid.Row="1" x:Name="litterReportLocationMap"
                               ItemsSource="{Binding LitterImageViewModels}">
                         <maps:Map.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                 <maps:Pin Location="{Binding Address.Location}"
                                           Address="{Binding Address.StreetAddress}"
                                           Label="Litter Image" />
@@ -72,7 +73,7 @@
                                     ItemsSource="{Binding LitterImageViewModels}"
                                     SelectionMode="None">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                 <Border Style="{StaticResource RoundBorder}">
                                     <Grid WidthRequest="400"
                                           ColumnDefinitions="*, 1*, 1*"

--- a/TrashMobMobile/Pages/EditPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/EditPickupLocationPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:EditPickupLocationViewModel"
              x:Class="TrashMobMobile.Pages.EditPickupLocationPage"
              Title="Edit Pickup Location">
     <ScrollView>

--- a/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
+++ b/TrashMobMobile/Pages/ManageEventPartnersPage.xaml
@@ -2,6 +2,8 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ManageEventPartnersViewModel"
              x:Class="TrashMobMobile.Pages.ManageEventPartnersPage"
              Title="Manage Event Partners">
     <ScrollView>
@@ -22,7 +24,7 @@
                                     SelectedItem="{Binding SelectedEventPartnerLocation}"
                                     SelectionMode="Single">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:EventPartnerLocationViewModel">
                                 <Border Style="{StaticResource RoundBorder}">
                                     <Grid ColumnDefinitions="1*, 1*, 1*"
                                           RowDefinitions="Auto"

--- a/TrashMobMobile/Pages/MyDashboardPage.xaml
+++ b/TrashMobMobile/Pages/MyDashboardPage.xaml
@@ -2,6 +2,8 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:MyDashboardViewModel"
              x:Class="TrashMobMobile.Pages.MyDashboardPage"
              Title="My Dashboard">
 
@@ -64,7 +66,7 @@
                                 Margin="5"
                                 MaximumHeightRequest="250">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
                             <Border Style="{StaticResource RoundBorder}" Margin="5">
                                 <Grid ColumnDefinitions="1*, 1*"
                                       RowDefinitions="Auto, Auto, Auto, Auto"
@@ -98,7 +100,7 @@
                                 Margin="5"
                                 MaximumHeightRequest="250">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
                             <Border Style="{StaticResource RoundBorder}" Margin="5">
                                 <Grid ColumnDefinitions="1*, 1*"
                                       RowDefinitions="Auto, Auto, Auto, Auto"
@@ -132,7 +134,7 @@
                                 Margin="5"
                                 MaximumHeightRequest="250">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:LitterReportViewModel">
                             <Border Style="{StaticResource RoundBorder}" Margin="5">
                                 <Grid ColumnDefinitions="1*, 1*"
                                       RowDefinitions="Auto, Auto, Auto, Auto"

--- a/TrashMobMobile/Pages/SearchEventsPage.xaml
+++ b/TrashMobMobile/Pages/SearchEventsPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:SearchEventsViewModel"
              x:Class="TrashMobMobile.Pages.SearchEventsPage"
              Title="Search Events">
     <ScrollView>
@@ -44,7 +46,7 @@
                           ItemsSource="{Binding Events}"
                           IsVisible="{Binding Source={x:Reference viewMap}, Path=IsChecked}">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
                             <maps:Pin Location="{Binding Address.Location}"
                                       Address="{Binding Address.StreetAddress}"
                                       Label="{Binding Name}"
@@ -60,7 +62,7 @@
                                 IsVisible="{Binding Source={x:Reference viewList}, Path=IsChecked }"
                                 SelectionMode="Single">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:EventViewModel">
                             <StackLayout Margin="5">
                                 <Border Style="{StaticResource RoundBorder}">
                                     <Grid ColumnDefinitions="1*, 1*"

--- a/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
+++ b/TrashMobMobile/Pages/SearchLitterReportsPage.xaml
@@ -2,6 +2,8 @@
 
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:SearchLitterReportsViewModel"
              x:Class="TrashMobMobile.Pages.SearchLitterReportsPage"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              Title="Search Litter Reports">
@@ -41,7 +43,7 @@
                               ItemsSource="{Binding LitterImages}"
                               IsVisible="{Binding Source={x:Reference viewMap}, Path=IsChecked}">
                         <maps:Map.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                 <maps:Pin Location="{Binding Address.Location}"
                                           Address="{Binding Address.StreetAddress}"
                                           Label="{Binding Address.StreetAddress}"
@@ -57,7 +59,7 @@
                                     IsVisible="{Binding Source={x:Reference viewList}, Path=IsChecked}"
                                     SelectionMode="Single">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:LitterReportViewModel">
                                 <StackLayout Margin="5">
                                     <Border Style="{StaticResource RoundBorder}">
                                         <Grid ColumnDefinitions="1*, 1*"
@@ -73,7 +75,7 @@
                                             <CollectionView ItemsSource="{Binding LitterImageViewModels}" Grid.Row="2"
                                                             Grid.Column="1">
                                                 <CollectionView.ItemTemplate>
-                                                    <DataTemplate>
+                                                    <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                                                         <Label Text="{Binding Address.DisplayAddress}" FontSize="Micro" />
                                                     </DataTemplate>
                                                 </CollectionView.ItemTemplate>

--- a/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
+++ b/TrashMobMobile/Pages/SetUserLocationPreferencePage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:UserLocationPreferenceViewModel"
              x:Class="TrashMobMobile.Pages.SetUserLocationPreferencePage"
              Title="Set Your Location">
     <ScrollView>
@@ -20,7 +22,7 @@
                           ItemsSource="{Binding Addresses}"
                           MapClicked="OnMapClicked">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:AddressViewModel">
                             <maps:Pin Location="{Binding Location}"
                                       Address="{Binding StreetAddress}"
                                       Label="Your Preferred Location" />

--- a/TrashMobMobile/Pages/ViewEventPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ViewEventViewModel"
              x:Class="TrashMobMobile.Pages.ViewEventPage"
              Title="Event Details">
     <ScrollView>
@@ -32,7 +34,7 @@
                     <maps:Map Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" x:Name="eventLocationMap"
                               ItemsSource="{Binding Events}">
                         <maps:Map.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:EventViewModel">
                                 <maps:Pin Location="{Binding Address.Location}"
                                           Address="{Binding Address.StreetAddress}"
                                           Label="{Binding Name}" />

--- a/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
+++ b/TrashMobMobile/Pages/ViewEventSummaryPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ViewEventSummaryViewModel"
              x:Class="TrashMobMobile.Pages.ViewEventSummaryPage"
              Title="Event Summary">
     <ScrollView>
@@ -59,7 +61,7 @@
                                     Grid.Row="4"
                                     Grid.ColumnSpan="2">
                         <CollectionView.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
                                 <StackLayout Margin="5">
                                     <Border Style="{StaticResource RoundBorder}">
                                         <Grid ColumnDefinitions="1*, 1*, 1*, 1*"
@@ -91,7 +93,7 @@
                               Grid.Row="4"
                               Grid.ColumnSpan="2">
                         <maps:Map.ItemTemplate>
-                            <DataTemplate>
+                            <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
                                 <maps:Pin Location="{Binding Address.Location}"
                                           Address="{Binding Address.StreetAddress}"
                                           Label="{Binding Id}"

--- a/TrashMobMobile/Pages/ViewLitterReportPage.xaml
+++ b/TrashMobMobile/Pages/ViewLitterReportPage.xaml
@@ -3,9 +3,10 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ViewLitterReportViewModel"
              x:Class="TrashMobMobile.Pages.ViewLitterReportPage"
              Title="Litter Report">
-
     <ScrollView>
         <Grid>
             <VerticalStackLayout Style="{StaticResource OuterVerticalStack}">
@@ -46,7 +47,7 @@
 
                 <maps:Map x:Name="litterReportLocationMap" ItemsSource="{Binding LitterImageViewModels}">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                             <maps:Pin Location="{Binding Address.Location}"
                                       Address="{Binding Address.StreetAddress}"
                                       Label="Litter Image" />
@@ -92,7 +93,7 @@
                                 ItemsSource="{Binding LitterImageViewModels}"
                                 SelectionMode="None">
                     <CollectionView.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:LitterImageViewModel">
                             <Border Style="{StaticResource RoundBorder}">
                                 <Grid WidthRequest="400"
                                       ColumnDefinitions="*, 1*"

--- a/TrashMobMobile/Pages/ViewPickupLocationPage.xaml
+++ b/TrashMobMobile/Pages/ViewPickupLocationPage.xaml
@@ -4,6 +4,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:ViewPickupLocationViewModel"
              x:Class="TrashMobMobile.Pages.ViewPickupLocationPage"
              Title="View Pickup Location">
     <ScrollView>
@@ -40,7 +42,7 @@
                           ItemsSource="{Binding PickupLocations}"
                           IsVisible="{Binding Source={x:Reference viewMap}, Path=IsChecked}">
                     <maps:Map.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="viewModels:PickupLocationViewModel">
                             <maps:Pin Location="{Binding Address.Location}"
                                       Address="{Binding Address.StreetAddress}"
                                       Label="{Binding Id}"

--- a/TrashMobMobile/Pages/WaiverPage.xaml
+++ b/TrashMobMobile/Pages/WaiverPage.xaml
@@ -3,6 +3,8 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+             xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
+             x:DataType="viewModels:WaiverViewModel"
              x:Class="TrashMobMobile.Pages.WaiverPage"
              Title="TrashMob.eco Waiver">
     <ScrollView>


### PR DESCRIPTION
Datatype binding is useful for development because it enables autocompletion with the viewmodel on the XAML.
Also prevents typos in the Binding.

For example upon Adding datatypes on the pages found out there was a typo in the Xaml  CreateEventPage line 57 
( Text="{Binding EventVieWModel.DurationHours}">) changed to  Text="{Binding EventViewModel.DurationHours}">

Right now I have 2 places on the app that the binding is giving errors. I need someone with experience on the project to check

1- **EditEventPage.Xaml** line 215 IsManageEventPartnersEnabled is not found EditEventViewModel
1- **EditEventPartnerLocationServicesViewPage.Xaml** line 34 EventPartnerLocationServiceViewModel does not contain a Notes Attribute 

