### PR TITLE
refactor(react-query): Remove unnecessary state from Homepage

### DIFF
--- a/TrashMob/client-app/src/components/Pages/Home.tsx
+++ b/TrashMob/client-app/src/components/Pages/Home.tsx
@@ -25,23 +25,29 @@ export interface HomeProps extends RouteComponentProps<any> {
     onUserUpdated: any;
 }
 
-const Home: FC<HomeProps> = ({ isUserLoaded, currentUser, history, location, match }) => {    
-    const [showModal, setShowSocialsModal] = useState<boolean>(false);
-    const [stats, setStats] = useState<StatsData | null>(null);
-
-    const handleShowModal = (showModal: boolean) => setShowSocialsModal(showModal);
-    const getStats = useQuery({ 
+const useGetHomeStats = () => {
+    return useQuery<StatsData>({ 
         queryKey: GetStats().key, 
         queryFn: GetStats().service,
+        initialData:() => ({
+            totalBags: 0,
+            totalEvents: 0,
+            totalHours: 0,
+            totalParticipants: 0,
+        }),
         staleTime: Services.CACHE.DISABLE,
-        enabled: false
     });
+}
+
+const Home: FC<HomeProps> = ({ isUserLoaded, currentUser, history, location, match }) => {    
+    const [showModal, setShowSocialsModal] = useState<boolean>(false);
+    const handleShowModal = (showModal: boolean) => setShowSocialsModal(showModal);
+
+    const { data: stats } = useGetHomeStats()
+    const { totalBags, totalEvents, totalHours, totalParticipants } = stats
 
     useEffect(() => {
         window.scrollTo(0, 0);
-        getStats.refetch().then(res => {
-            setStats(res.data?.data || null)
-        });
     }, [isUserLoaded, currentUser])
 
     return (
@@ -79,10 +85,10 @@ const Home: FC<HomeProps> = ({ isUserLoaded, currentUser, history, location, mat
             </div>
             <Container className="d-flex justify-content-around my-5 py-5 flex-column flex-md-row">
                 {[
-                    { id: 0, title: 'Events Hosted', value: stats?.totalEvents || 0, icon: Calendar, alt: 'Calendar icon' },
-                    { id: 1, title: 'Bags Collected', value: stats?.totalBags || 0, icon: Trashbag, alt: 'Trashbag icon' },
-                    { id: 2, title: 'Participants', value: stats?.totalParticipants || 0, icon: Person, alt: 'Person icon' },
-                    { id: 3, title: 'Hours Spent', value: stats?.totalHours || 0, icon: Clock, alt: 'Clock icon' },
+                    { id: 0, title: 'Events Hosted', value: totalEvents, icon: Calendar, alt: 'Calendar icon' },
+                    { id: 1, title: 'Bags Collected', value: totalBags, icon: Trashbag, alt: 'Trashbag icon' },
+                    { id: 2, title: 'Participants', value: totalParticipants, icon: Person, alt: 'Person icon' },
+                    { id: 3, title: 'Hours Spent', value: totalHours, icon: Clock, alt: 'Clock icon' },
                 ].map(item => (
                     <div key={item.id} className="d-flex flex-column justify-content-center text-center">
                         <img src={item.icon} alt={item.alt} className="w-auto mx-auto mb-3" />

--- a/TrashMob/client-app/src/services/stats.ts
+++ b/TrashMob/client-app/src/services/stats.ts
@@ -2,7 +2,13 @@ import { ApiService } from ".";
 import StatsData from "../components/Models/StatsData";
 
 export type GetStats_Response = StatsData;
-export const GetStats = () => ({ key: ['/stats'], service: async () => ApiService('public').fetchData<GetStats_Response>({ url: `/stats`, method: 'get' }) });
+export const GetStats = () => ({
+  key: ['/stats'],
+  service: async () => 
+    ApiService('public')
+      .fetchData<GetStats_Response>({ url: `/stats`, method: 'get' })
+      .then((res) => res.data)
+});
 
 export type GetStatsForUser_Params = { userId: string; };
 export type GetStatsForUser_Response = StatsData;


### PR DESCRIPTION
This PR remove state "stats" from Home page, and use data stored in QueryClient instead.

It also separate data logic from render logic

Data logic
- Query Key
- Query Function
- Initial default value

Render logic
- Just render with no care in the world.

Additionally, I think service should not return AxiosResponse, but return the actual "data", so the React component doesn't have to know axios logic `data is in res.data`