### PR TITLE
Filter out events instead of returning a React Fragment

### DIFF
--- a/TrashMob/client-app/src/components/Pages/MyDashboard.tsx
+++ b/TrashMob/client-app/src/components/Pages/MyDashboard.tsx
@@ -400,34 +400,26 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         return (
             <div className="bg-white p-3 px-4">
                 <Table columnHeaders={headerTitles} >
-                    {myEventList.sort((a, b) => (a.eventDate < b.eventDate) ? 1 : -1).map(event => {
-                        if (new Date(event.eventDate) >= new Date()) {
-                            return (
-                                <tr key={event.id.toString()}>
-                                    <td>{event.name}</td>
-                                    <td>{event.createdByUserId === props.currentUser.id ? 'Lead' : ' Attendee'}</td>
-                                    <td>{new Date(event.eventDate).toLocaleDateString("en-us", {
-                                        year: "numeric",
-                                        month: "2-digit",
-                                        day: "2-digit"
-                                    })}</td>
-                                    <td>{new Date(event.eventDate).toLocaleTimeString("en-us", { hour12: true, hour: 'numeric', minute: '2-digit' })}</td>
-                                    <td>{event.streetAddress}, {event.city}</td>
-                                    <td className="btn py-0">
-                                        <Dropdown role="menuitem">
-                                            <Dropdown.Toggle id="share-toggle" variant="outline" className="h-100 border-0">...</Dropdown.Toggle>
-                                            <Dropdown.Menu id="share-menu">
-                                                {event.createdByUserId === props.currentUser.id ? eventOwnerActionDropdownList(event) : attendeeActionDropdownList(event)}
-                                            </Dropdown.Menu>
-                                        </Dropdown>
-                                    </td>
-                                </tr>
-                            )
-                        } else {
-                            return (<></>)
-                        }
-                    }
-                    )}
+                    {myEventList
+                        .sort((a, b) => (a.eventDate < b.eventDate) ? 1 : -1)
+                        .filter(({ eventDate }) => new Date(eventDate) >= new Date())
+                        .map(event => (
+                            <tr key={event.id.toString()}>
+                                <td>{event.name}</td>
+                                <td>{event.createdByUserId === props.currentUser.id ? 'Lead' : ' Attendee'}</td>
+                                <td>{new Date(event.eventDate).toLocaleDateString("en-us", { year: "numeric", month: "2-digit", day: "2-digit" })}</td>
+                                <td>{new Date(event.eventDate).toLocaleTimeString("en-us", { hour12: true, hour: 'numeric', minute: '2-digit' })}</td>
+                                <td>{event.streetAddress}, {event.city}</td>
+                                <td className="btn py-0">
+                                    <Dropdown role="menuitem">
+                                        <Dropdown.Toggle id="share-toggle" variant="outline" className="h-100 border-0">...</Dropdown.Toggle>
+                                        <Dropdown.Menu id="share-menu">
+                                            {event.createdByUserId === props.currentUser.id ? eventOwnerActionDropdownList(event) : attendeeActionDropdownList(event)}
+                                        </Dropdown.Menu>
+                                    </Dropdown>
+                                </td>
+                            </tr>
+                        ))}
                 </Table>
             </div >
         );
@@ -438,34 +430,26 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         return (
             <div className="bg-white p-3 px-4">
                 <Table columnHeaders={headerTitles}>
-                    {myEventList.sort((a, b) => (a.eventDate < b.eventDate) ? 1 : -1).map(event => {
-                            if (new Date(event.eventDate) < new Date()) {
-                                return (
-                                    <tr key={event.id.toString()}>
-                                        <td>{event.name}</td>
-                                        <td>{event.createdByUserId === props.currentUser.id ? 'Lead' : ' Attendee'}</td>
-                                        <td>{new Date(event.eventDate).toLocaleDateString("en-us", {
-                                            year: "numeric",
-                                            month: "2-digit",
-                                            day: "2-digit"
-                                        })}</td>
-                                        <td>{new Date(event.eventDate).toLocaleTimeString("en-us", { hour12: true, hour: 'numeric', minute: '2-digit' })}</td>
-                                        <td>{event.streetAddress}, {event.city}</td>
-                                        <td className="btn py-0">
-                                            <Dropdown role="menuitem">
-                                                <Dropdown.Toggle id="share-toggle" variant="outline" className="h-100 border-0">...</Dropdown.Toggle>
-                                                <Dropdown.Menu id="share-menu">
-                                                    {event.createdByUserId === props.currentUser.id ? completedEventOwnerActionDropdownList(event.id) : completedAttendeeActionDropdownList(event.id)}
-                                                </Dropdown.Menu>
-                                            </Dropdown>
-                                        </td>
-                                    </tr>
-                                )
-                            } else {
-                                return (<></>)
-                            }
-                        }
-                        )}
+                    {myEventList
+                        .sort((a, b) => (a.eventDate < b.eventDate) ? 1 : -1)
+                        .filter(({ eventDate }) => new Date(eventDate) < new Date())
+                        .map(({ id, name, createdByUserId, eventDate, streetAddress, city}) => (
+                            <tr key={id.toString()}>
+                                <td>{name}</td>
+                                <td>{createdByUserId === props.currentUser.id ? 'Lead' : ' Attendee'}</td>
+                                <td>{new Date(eventDate).toLocaleDateString("en-us", { year: "numeric", month: "2-digit", day: "2-digit" })}</td>
+                                <td>{new Date(eventDate).toLocaleTimeString("en-us", { hour12: true, hour: 'numeric', minute: '2-digit' })}</td>
+                                <td>{streetAddress}, {city}</td>
+                                <td className="btn py-0">
+                                    <Dropdown role="menuitem">
+                                        <Dropdown.Toggle id="share-toggle" variant="outline" className="h-100 border-0">...</Dropdown.Toggle>
+                                        <Dropdown.Menu id="share-menu">
+                                            {createdByUserId === props.currentUser.id ? completedEventOwnerActionDropdownList(id) : completedAttendeeActionDropdownList(id)}
+                                        </Dropdown.Menu>
+                                    </Dropdown>
+                                </td>
+                            </tr>
+                        ))}
                 </Table>
             </div >
         )
@@ -504,8 +488,7 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         else {
             return (
                 <div className="bg-white p-3 px-4">
-                    <Table columnHeaders={headerTitles} >
-                    </Table>
+                    <Table columnHeaders={headerTitles}><></></Table>
                 </div >
             )
         }
@@ -543,8 +526,7 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         else {
             return (
                 <div className="bg-white p-3 px-4">
-                    <Table columnHeaders={headerTitles} >
-                    </Table>
+                    <Table columnHeaders={headerTitles}><></></Table>
                 </div >
             )
         }
@@ -580,8 +562,7 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         else {
             return (
                 <div className="bg-white p-3 px-4">
-                    <Table columnHeaders={headerTitles} >
-                    </Table>
+                    <Table columnHeaders={headerTitles}><></></Table>
                 </div >
             )
         }
@@ -617,8 +598,7 @@ const MyDashboard: FC<MyDashboardProps> = (props) => {
         else {
             return (
                 <div className="bg-white p-3 px-4">
-                    <Table columnHeaders={headerTitles} >
-                    </Table>
+                    <Table columnHeaders={headerTitles}><></></Table>
                 </div >
             )
         }


### PR DESCRIPTION
This PR fixes the following error in the Dashboard page. This error would be shown if the list of `Past events` or `Upcoming Events` are empty.

Related issue: https://github.com/TrashMob-eco/TrashMob/issues/1612

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `UpcomingEventsTable`. See https://reactjs.org/link/warning-keys for more information.
    at UpcomingEventsTable
    at div
    at div
    at http://localhost:3000/static/js/bundle.js:163656:23
    at MyDashboard (http://localhost:3000/static/js/bundle.js:20370:88)
    at C (http://localhost:3000/static/js/bundle.js:199851:37)
    at MsalAuthenticationTemplate (http://localhost:3000/static/js/bundle.js:60393:5)
    at Route (http://localhost:3000/static/js/bundle.js:199634:29)
    at Switch (http://localhost:3000/static/js/bundle.js:199803:29)
    at div
    at Router (http://localhost:3000/static/js/bundle.js:199306:30)
    at BrowserRouter (http://localhost:3000/static/js/bundle.js:198821:35)
    at div
    at MsalProvider (http://localhost:3000/static/js/bundle.js:59977:5)
    at QueryClientProvider (http://localhost:3000/static/js/bundle.js:221969:5)
    at App (http://localhost:3000/static/js/bundle.js:1525:90)
```

More specifically:
- It filter outs the events instead of returning a Fragment (that's the cause of some element not having a `key`)
- It does some minor code formatting.
- It fixes some TS errors in the code which complains the tables don't have children.

QA steps:
- The upcoming and past event should look exactly the same.
- My partnership section should look the same
