### PR TITLE
Fix: LocationPreference / Azure Search Address Reverse send wrong lat & lng

### DIFF
--- a/TrashMob/client-app/src/components/Pages/LocationPreference.tsx
+++ b/TrashMob/client-app/src/components/Pages/LocationPreference.tsx
@@ -208,7 +208,7 @@ const LocationPreference: FC<LocationPreferenceProps> = (props) => {
         setLatitude(point[1]);
         setLongitude(point[0]);
         const azureKey = await getKey();
-        azureMapSearchAddressReverse.mutateAsync({ azureKey, lat: point[0], long: point[1] }).then((res) => {
+        azureMapSearchAddressReverse.mutateAsync({ azureKey, lat: point[1], long: point[0] }).then((res) => {
             setCity(res.data.addresses[0].address.municipality);
             setCountry(res.data.addresses[0].address.country);
             setRegion(res.data.addresses[0].address.countrySubdivisionName);


### PR DESCRIPTION
<img width="640" alt="image" src="https://github.com/user-attachments/assets/010d99d1-89b4-40b5-8422-3c3f96776295">

From the screenshot, Bangkok should have latitude 13.xxx and longitude 100.xxxx.