### PR TITLE
Trigger the onUserUpdated when waiver signs the form

### DIFF
--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -321,7 +321,7 @@ export const App: FC = () => {
                                         errorComponent={ErrorComponent}
                                         loadingComponent={LoadingComponent}
                                     >
-                                        {isUserLoaded ? <Waivers currentUser={currentUser} /> : null}
+                                        {isUserLoaded ? <Waivers currentUser={currentUser} onUserUpdated={handleUserUpdated}  /> : null}
                                     </MsalAuthenticationTemplate>
                                 </Route>
                                 <Route exact path='/partnerships'>

--- a/TrashMob/client-app/src/components/Waivers/Waivers.tsx
+++ b/TrashMob/client-app/src/components/Waivers/Waivers.tsx
@@ -17,6 +17,7 @@ type WaiverFormInputs = {
 
 export interface WaiversProps {
     currentUser: UserData;
+    onUserUpdated: () => void;
 }
 
 export const CurrentTrashMobWaiverVersion = {
@@ -24,7 +25,7 @@ export const CurrentTrashMobWaiverVersion = {
     versionDate: new Date(2023, 6, 1, 0, 0, 0, 0),
 };
 
-const Waivers: React.FC<WaiversProps> = ({ currentUser }) => {
+const Waivers: React.FC<WaiversProps> = ({ currentUser, onUserUpdated }) => {
     const history = useHistory();
     const queryClient = useQueryClient();
     const userId = currentUser.id;
@@ -46,7 +47,8 @@ const Waivers: React.FC<WaiversProps> = ({ currentUser }) => {
         onSuccess: async () => {
             // Invalidate query
             await queryClient.invalidateQueries(GetUserById({ userId }).key);
-
+            onUserUpdated();
+            
             // Then redirect to home
             history.push('/');
         },


### PR DESCRIPTION
An issue was introduced in a PR that [updates the waiver process](https://github.com/TrashMob-eco/TrashMob/pull/1675/files?diff=split&w=0). In the former flow, the user was updated in the `WaiversReturn` page which does not exist anymore. 

This PR adds the callback to update the user in the `Waivers` page onSuccess.