### PR TITLE
Simplify useLogin by replacing currentUser state with react-query cache

### DIFF
--- a/TrashMob/client-app/src/App.tsx
+++ b/TrashMob/client-app/src/App.tsx
@@ -6,8 +6,6 @@ import { BrowserRouter, RouteComponentProps } from 'react-router-dom';
 import { initializeIcons } from '@uifabric/icons';
 import { MsalAuthenticationResult, MsalAuthenticationTemplate, MsalProvider } from '@azure/msal-react';
 import { InteractionType } from '@azure/msal-browser';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import Home from './components/Pages/Home';
 
 import { AboutUs } from './components/Pages/AboutUs';
@@ -56,8 +54,6 @@ interface DetailsProps extends RouteComponentProps<DetailsMatchParams> {}
 interface PartnerRequestDetailsProps extends RouteComponentProps<PartnerRequestDetailsMatchParams> {}
 
 interface DeleteMyDataProps extends RouteComponentProps {}
-
-const queryClient = new QueryClient();
 
 const useInitializeApp = () => {
     const [isInitialized, setIsInitialized] = useState(false);
@@ -156,162 +152,140 @@ export const App: FC = () => {
     }
 
     return (
-        <QueryClientProvider client={queryClient}>
-            <MsalProvider instance={msalClient}>
-                <div className='d-flex flex-column h-100'>
-                    <BrowserRouter>
-                        <SiteHeader currentUser={currentUser} isUserLoaded={isUserLoaded} />
-                        <div className='container-fluid px-0'>
-                            <Switch>
-                                <Route
-                                    path='/manageeventdashboard/:eventId?'
-                                    render={(props: AppProps) => renderEditEvent(props)}
+        <div className='d-flex flex-column h-100'>
+            <BrowserRouter>
+                <SiteHeader currentUser={currentUser} isUserLoaded={isUserLoaded} />
+                <div className='container-fluid px-0'>
+                    <Switch>
+                        <Route
+                            path='/manageeventdashboard/:eventId?'
+                            render={(props: AppProps) => renderEditEvent(props)}
+                        />
+                        <Route
+                            path='/partnerdashboard/:partnerId?'
+                            render={(props: PartnerProps) => renderPartnerDashboard(props)}
+                        />
+                        <Route
+                            path='/partnerrequestdetails/:partnerRequestId'
+                            render={(props: PartnerRequestDetailsProps) => renderPartnerRequestDetails(props)}
+                        />
+                        <Route path='/eventsummary/:eventId?' render={(props: AppProps) => renderEventSummary(props)} />
+                        <Route
+                            path='/eventdetails/:eventId'
+                            render={(props: DetailsProps) => renderEventDetails(props)}
+                        />
+                        <Route path='/cancelevent/:eventId' render={(props: CancelProps) => renderCancelEvent(props)} />
+                        <Route path='/deletemydata' render={(props: DeleteMyDataProps) => renderDeleteMyData(props)} />
+                        <Route exact path='/mydashboard'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                <MyDashboard currentUser={currentUser} isUserLoaded={isUserLoaded} />
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/becomeapartner'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                <PartnerRequest currentUser={currentUser} isUserLoaded={isUserLoaded} mode='become' />
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/inviteapartner'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                <PartnerRequest currentUser={currentUser} isUserLoaded={isUserLoaded} mode='send' />
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/siteadmin'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                <SiteAdmin currentUser={currentUser} isUserLoaded={isUserLoaded} />
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/locationpreference'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                <LocationPreference
+                                    currentUser={currentUser}
+                                    isUserLoaded={isUserLoaded}
+                                    onUserUpdated={handleUserUpdated}
                                 />
-                                <Route
-                                    path='/partnerdashboard/:partnerId?'
-                                    render={(props: PartnerProps) => renderPartnerDashboard(props)}
-                                />
-                                <Route
-                                    path='/partnerrequestdetails/:partnerRequestId'
-                                    render={(props: PartnerRequestDetailsProps) => renderPartnerRequestDetails(props)}
-                                />
-                                <Route
-                                    path='/eventsummary/:eventId?'
-                                    render={(props: AppProps) => renderEventSummary(props)}
-                                />
-                                <Route
-                                    path='/eventdetails/:eventId'
-                                    render={(props: DetailsProps) => renderEventDetails(props)}
-                                />
-                                <Route
-                                    path='/cancelevent/:eventId'
-                                    render={(props: CancelProps) => renderCancelEvent(props)}
-                                />
-                                <Route
-                                    path='/deletemydata'
-                                    render={(props: DeleteMyDataProps) => renderDeleteMyData(props)}
-                                />
-                                <Route exact path='/mydashboard'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        <MyDashboard currentUser={currentUser} isUserLoaded={isUserLoaded} />
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/becomeapartner'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        <PartnerRequest
-                                            currentUser={currentUser}
-                                            isUserLoaded={isUserLoaded}
-                                            mode='become'
-                                        />
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/inviteapartner'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        <PartnerRequest
-                                            currentUser={currentUser}
-                                            isUserLoaded={isUserLoaded}
-                                            mode='send'
-                                        />
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/siteadmin'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        <SiteAdmin currentUser={currentUser} isUserLoaded={isUserLoaded} />
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/locationpreference'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        <LocationPreference
-                                            currentUser={currentUser}
-                                            isUserLoaded={isUserLoaded}
-                                            onUserUpdated={handleUserUpdated}
-                                        />
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/waivers'>
-                                    <MsalAuthenticationTemplate
-                                        interactionType={InteractionType.Redirect}
-                                        errorComponent={ErrorComponent}
-                                        loadingComponent={LoadingComponent}
-                                    >
-                                        {isUserLoaded ? (
-                                            <Waivers currentUser={currentUser} onUserUpdated={handleUserUpdated} />
-                                        ) : null}
-                                    </MsalAuthenticationTemplate>
-                                </Route>
-                                <Route exact path='/partnerships'>
-                                    <Partnerships />
-                                </Route>
-                                <Route exact path='/shop'>
-                                    <Shop />
-                                </Route>
-                                <Route exact path='/help'>
-                                    <Help />
-                                </Route>
-                                <Route exact path='/aboutus'>
-                                    <AboutUs />
-                                </Route>
-                                <Route exact path='/board'>
-                                    <Board />
-                                </Route>
-                                <Route exact path='/contactus'>
-                                    <ContactUs />
-                                </Route>
-                                <Route exact path='/eventsummaries'>
-                                    <EventSummaries />
-                                </Route>
-                                <Route exact path='/faq'>
-                                    <Faq />
-                                </Route>
-                                <Route exact path='/gettingstarted'>
-                                    <GettingStarted />
-                                </Route>
-                                <Route exact path='/privacypolicy'>
-                                    <PrivacyPolicy />
-                                </Route>
-                                <Route exact path='/termsofservice'>
-                                    <TermsOfService />
-                                </Route>
-                                <Route exact path='/volunteeropportunities'>
-                                    <VolunteerOpportunities />
-                                </Route>
-                                <Route exact path='/'>
-                                    <Home
-                                        currentUser={currentUser}
-                                        isUserLoaded={isUserLoaded}
-                                        onUserUpdated={handleUserUpdated}
-                                    />
-                                </Route>
-                                <Route>
-                                    <NoMatch />
-                                </Route>
-                            </Switch>
-                        </div>
-                        <SiteFooter />
-                    </BrowserRouter>
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/waivers'>
+                            <MsalAuthenticationTemplate
+                                interactionType={InteractionType.Redirect}
+                                errorComponent={ErrorComponent}
+                                loadingComponent={LoadingComponent}
+                            >
+                                {isUserLoaded ? (
+                                    <Waivers currentUser={currentUser} onUserUpdated={handleUserUpdated} />
+                                ) : null}
+                            </MsalAuthenticationTemplate>
+                        </Route>
+                        <Route exact path='/partnerships'>
+                            <Partnerships />
+                        </Route>
+                        <Route exact path='/shop'>
+                            <Shop />
+                        </Route>
+                        <Route exact path='/help'>
+                            <Help />
+                        </Route>
+                        <Route exact path='/aboutus'>
+                            <AboutUs />
+                        </Route>
+                        <Route exact path='/board'>
+                            <Board />
+                        </Route>
+                        <Route exact path='/contactus'>
+                            <ContactUs />
+                        </Route>
+                        <Route exact path='/eventsummaries'>
+                            <EventSummaries />
+                        </Route>
+                        <Route exact path='/faq'>
+                            <Faq />
+                        </Route>
+                        <Route exact path='/gettingstarted'>
+                            <GettingStarted />
+                        </Route>
+                        <Route exact path='/privacypolicy'>
+                            <PrivacyPolicy />
+                        </Route>
+                        <Route exact path='/termsofservice'>
+                            <TermsOfService />
+                        </Route>
+                        <Route exact path='/volunteeropportunities'>
+                            <VolunteerOpportunities />
+                        </Route>
+                        <Route exact path='/'>
+                            <Home
+                                currentUser={currentUser}
+                                isUserLoaded={isUserLoaded}
+                                onUserUpdated={handleUserUpdated}
+                            />
+                        </Route>
+                        <Route>
+                            <NoMatch />
+                        </Route>
+                    </Switch>
                 </div>
-            </MsalProvider>
-            <ReactQueryDevtools initialIsOpen={false} />
-        </QueryClientProvider>
+                <SiteFooter />
+            </BrowserRouter>
+        </div>
     );
 };

--- a/TrashMob/client-app/src/hooks/useLogin.ts
+++ b/TrashMob/client-app/src/hooks/useLogin.ts
@@ -45,7 +45,7 @@ const useGetProfile = (account: TrashmobAccountInfo, email: string) => {
                 } else {
                     console.error('Error fetching user profile:', error);
                 }
-                return emptyUser
+                return emptyUser;
             }
         },
         initialData: emptyUser, // Empty UserData

--- a/TrashMob/client-app/src/index.tsx
+++ b/TrashMob/client-app/src/index.tsx
@@ -1,13 +1,25 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { MsalProvider } from '@azure/msal-react';
+
 import './index.css';
+import { msalClient } from './store/AuthStore';
 import { App } from './App';
 import reportWebVitals from './reportWebVitals';
 import './themed-bootstrap.scss';
 
+const queryClient = new QueryClient();
+
 ReactDOM.render(
     <React.StrictMode>
-        <App />
+        <QueryClientProvider client={queryClient}>
+            <MsalProvider instance={msalClient}>
+                <App />
+            </MsalProvider>
+            <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
     </React.StrictMode>,
     document.getElementById('root'),
 );


### PR DESCRIPTION
### Removed functions
- initialLogin --- replaced with `const { accounts } = useMsal()`
- verifyAccount --- Its function is to get user profile from email, replaced with query.refetch
- clearUser --- no need to clearUser because we use email as queryKey

### Removed state 
- currentUser --- replaced with useQuery cache
- callbackId --- It was used to fetch user profile & clear user when loggedIn or loggedOut, but without `currentUser` state, it doesn't serve a purpose anymore.


```
export const useLogin = () => {
    const { accounts } = useMsal(); // Hook to access MSAL accounts
    const account = accounts[0] as TrashmobAccountInfo;

    const email = account?.idTokenClaims?.email ?? '';

    const { data: profile, refetch: refetchProfile } = useGetProfile(account, email);

    async function handleUserUpdated() {
        refetchProfile();
    }

    return {
        isUserLoaded: !!profile?.email,
        currentUser: profile,
        handleUserUpdated,
    };
};
```