### PR TITLE
Fix header mishap on some screen size

### DIFF
--- a/TrashMob/client-app/src/components/SiteHeader/SiteHeader.tsx
+++ b/TrashMob/client-app/src/components/SiteHeader/SiteHeader.tsx
@@ -43,14 +43,14 @@ export const SiteHeader = (props: SiteHeaderProps) => {
                                 'lg:items-center lg:justify-between lg:flex-row lg:basis-0',
                                 'lg:max-h-none',
                                 {
-                                    'max-h-64': show,
+                                    'max-h-84': show,
                                     'max-h-0': !show,
                                 },
                             )}
                         >
                             <MainNav className='flex-1 !py-4 lg:!py-0' isUserLoaded={isUserLoaded} />
                             <div className={cn('flex flex-row gap-4')}>
-                                <Button asChild>
+                                <Button asChild className='flex md:hidden xl:flex'>
                                     <Link to='/manageeventdashboard'>
                                         <Plus /> Create an Event
                                     </Link>


### PR DESCRIPTION
Fix there's not enough space for all items in 1000-1280 px screen size

### Before
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/12ebbaaf-c83c-4c29-8bf0-5548025d3ad2">

### After
<img width="1058" alt="image" src="https://github.com/user-attachments/assets/b293c6b2-69de-42f8-9bec-619235e6f760">

-----

Fix sign in & create event button missing in mobile

### Before
<img width="512" alt="image" src="https://github.com/user-attachments/assets/48df3eb0-59bf-45a9-8cd0-efb014ccf863">

### After
<img width="484" alt="image" src="https://github.com/user-attachments/assets/dcf97520-771c-4bdb-a126-2d2197415d91">
