### PR TITLE
Location Tracking for iOS Part 1

### DIFF
--- a/TrashMobMobile/Platforms/iOS/GeolocatorImplementation.cs
+++ b/TrashMobMobile/Platforms/iOS/GeolocatorImplementation.cs
@@ -12,7 +12,7 @@
 
         public async Task StartListening(IProgress<Location> positionChangedProgress, CancellationToken cancellationToken)
         {
-            var permission = await Permissions.CheckStatusAsync<Permissions.LocationAlways>();
+            var permission = await Permissions.CheckStatusAsync<Permissions.LocationWhenInUse>();
             if (permission != PermissionStatus.Granted)
             {
                 permission = await Permissions.RequestAsync<Permissions.LocationAlways>();
@@ -29,6 +29,9 @@
                 manager.LocationsUpdated -= PositionChanged;
                 taskCompletionSource.TrySetResult();
             });
+            manager.PausesLocationUpdatesAutomatically = false;
+            manager.AllowsBackgroundLocationUpdates = true; // ✅ Ensures updates even in background
+            manager.StartUpdatingLocation(); // ✅ Ensure location tracking starts
             manager.LocationsUpdated += PositionChanged;
 
             void PositionChanged(object? sender, CLLocationsUpdatedEventArgs args)

--- a/TrashMobMobile/Platforms/iOS/GeolocatorImplementation.cs
+++ b/TrashMobMobile/Platforms/iOS/GeolocatorImplementation.cs
@@ -8,7 +8,7 @@
 
     public class GeolocatorImplementation : IGeolocator
     {
-        readonly CLLocationManager manager = new();
+        private readonly CLLocationManager manager = new();
 
         public async Task StartListening(IProgress<Location> positionChangedProgress, CancellationToken cancellationToken)
         {
@@ -27,8 +27,10 @@
             cancellationToken.Register(() =>
             {
                 manager.LocationsUpdated -= PositionChanged;
+                manager.StopUpdatingLocation();
                 taskCompletionSource.TrySetResult();
             });
+            
             manager.PausesLocationUpdatesAutomatically = false;
             manager.AllowsBackgroundLocationUpdates = true; // ✅ Ensures updates even in background
             manager.StartUpdatingLocation(); // ✅ Ensure location tracking starts

--- a/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
+++ b/TrashMobMobile/Views/ViewEvent/TabDetails.xaml
@@ -4,6 +4,7 @@
              xmlns:maps="http://schemas.microsoft.com/dotnet/2021/maui/maps"
              xmlns:viewModels="clr-namespace:TrashMobMobile.ViewModels"
              xmlns:controls="clr-namespace:TrashMobMobile.Controls"
+             x:DataType="viewModels:ViewEventViewModel"
              x:Class="TrashMobMobile.Views.ViewEvent.TabDetails">
     <Grid RowDefinitions="Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto, Auto" RowSpacing="3"
                       ColumnDefinitions="*, 2*, *">
@@ -67,7 +68,7 @@
                             Text="View Event Summary"
                             IsVisible="{Binding EnableViewEventSummary}"
                             Style="{StaticResource SecondarySmallButton}" />
-            <!--<Button Margin="5"
+            <Button Margin="5"
                             Grid.Row="0" 
                             Grid.Column="2" 
                             Command="{Binding RealTimeLocationTrackerCommand}" 
@@ -82,7 +83,7 @@
                             IsEnabled="{Binding EnableStopTrackEventRoute}"
                             IsVisible="{Binding EnableStopTrackEventRoute}"
                             Text="Stop Tracking" 
-                            Style="{StaticResource SecondarySmallButton}" />-->
+                            Style="{StaticResource SecondarySmallButton}" />
         </Grid>
     </Grid>
 </ContentView>

--- a/TrashMobMobile/simulate_locations.sh
+++ b/TrashMobMobile/simulate_locations.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Array of sample latitude,longitude coordinates (comma-separated)
+LOCATIONS=(
+    "37.7749,-122.4194"  # San Francisco
+    "40.7128,-74.0060"   # New York
+    "34.0522,-118.2437"  # Los Angeles
+    "51.5074,-0.1278"    # London
+    "48.8566,2.3522"     # Paris
+    "35.6895,139.6917"   # Tokyo
+    "55.7558,37.6173"    # Moscow
+    "19.4326,-99.1332"   # Mexico City
+    "39.9042,116.4074"   # Beijing
+    "1.3521,103.8198"    # Singapore
+    "41.9028,12.4964"    # Rome
+    "-33.8688,151.2093"  # Sydney
+    "-23.5505,-46.6333"  # São Paulo
+    "52.5200,13.4050"    # Berlin
+    "31.2304,121.4737"   # Shanghai
+)
+
+for LOCATION in "${LOCATIONS[@]}"; do
+    echo "Setting location to: $LOCATION"
+    xcrun simctl location booted set $LOCATION
+    sleep 4 # Wait 4 seconds before changing to the next location
+done
+
+echo "✅ Location simulation completed!"#!/bin/bash


### PR DESCRIPTION
Added a location simulator for iOS emulators. Just run the file on the terminal and it will simulate 15 locations over a minute.
This is very important to test locations. 
You can put a breakpoint inside the following function to test.
```
void PositionChanged(object? sender, CLLocationsUpdatedEventArgs args)
            {
                if (args.Locations.Length > 0)
                {
                    var coordinate = args.Locations[^1].Coordinate;
                    positionChangedProgress.Report(new Location(coordinate.Latitude, coordinate.Longitude));
                }
            }
```
Changed the permission to LocationWhenInUse this will track when the app is open and when is on background.
We may need to change the permission strategy because the previous code failed if the user denied LocationAlways Permission.
