### PR TITLE
[S] Workaround for iPad Air issue with Sentry initialization (Aot compilation)

### DIFF
--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -33,25 +33,30 @@ public static class MauiProgram
                 fonts.AddFont("googlematerialdesignicons-webfont.ttf", "GoogleMaterialIcons");
             });
 
-        builder.UseSentry(options =>
-        {
-            // The DSN is the only required setting.
-            options.Dsn =
-                "https://4be7fb697cee47ce9554bb64f7d6a476@o4505460799045632.ingest.sentry.io/4505460800225280";
+            //Sentry AOT SHA initialization issues in ipad air
+            if (DeviceInfo.Name != null && !DeviceInfo.Name.Contains("iPad Air"))
+            {
+                builder.UseSentry(options =>
+                {
+                    // The DSN is the only required setting.
+                    options.Dsn =
+                        "https://4be7fb697cee47ce9554bb64f7d6a476@o4505460799045632.ingest.sentry.io/4505460800225280";
 
-            // Use debug mode if you want to see what the SDK is doing.
-            // Debug messages are written to stdout with Console.Writeline,
-            // and are viewable in your IDE's debug console or with 'adb logcat', etc.
-            // This option is not recommended when deploying your application.
-            options.Debug = false;
+                    // Use debug mode if you want to see what the SDK is doing.
+                    // Debug messages are written to stdout with Console.Writeline,
+                    // and are viewable in your IDE's debug console or with 'adb logcat', etc.
+                    // This option is not recommended when deploying your application.
+                    options.Debug = false;
 
-            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-            // We recommend adjusting this value in production.
-            options.TracesSampleRate = 1.0;
+                    // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+                    // We recommend adjusting this value in production.
+                    options.TracesSampleRate = 1.0;
 
-            // Other Sentry options can be set here.
-            options.CaptureFailedRequests = true;
-        });
+                    // Other Sentry options can be set here.
+                    options.CaptureFailedRequests = true;
+                });
+            }
+
 
         // Services
         builder.Services.AddSingleton<AuthHandler>();

--- a/TrashMobMobile/Platforms/iOS/Info.plist
+++ b/TrashMobMobile/Platforms/iOS/Info.plist
@@ -6,6 +6,7 @@
     <true/>
     <key>UIDeviceFamily</key>
     <array>
+      <integer>1</integer>
       <integer>2</integer>
     </array>
     <key>UIRequiredDeviceCapabilities</key>

--- a/TrashMobMobile/Platforms/iOS/Info.plist
+++ b/TrashMobMobile/Platforms/iOS/Info.plist
@@ -6,7 +6,7 @@
     <true/>
     <key>UIDeviceFamily</key>
     <array>
-      <integer>1</integer>
+      <integer>2</integer>
     </array>
     <key>UIRequiredDeviceCapabilities</key>
     <array>


### PR DESCRIPTION
 Sentry is using SHA1 via dynamic invocation, which causes JIT to kick in — but iOS blocks it → and you crash.
Sentry SDK is trying to dynamically hash something (probably DSN caching or breadcrumbs), and internally it does this:
var sha1 = SHA1.Create(); // This fails on iOS AOT-only builds

