### PR TITLE
Disable sentry for IOS

### DIFF
--- a/.github/workflows/PullRequest-Mobile.yml
+++ b/.github/workflows/PullRequest-Mobile.yml
@@ -13,8 +13,8 @@ on:
       - 'TrashMobMobileApp.sln'
 
 env:
-  DOTNET_VERSION: '9.0.x'   # set this to the dotnet version to use
-  DOTNET_VERSION2: '9.0.x'  # set this to the dotnet version to use
+  DOTNET_VERSION: '9.0.100'   # set this to the dotnet version to use
+  DOTNET_VERSION2: '9.0.100'  # set this to the dotnet version to use
   CONFIGURATION: Release      # Values: Debug, Release
   ENVIRONMENT: test         # Values: test, production
   IOS_BUNDLE_ID: 'eco.trashmobdev.trashmobmobile'   # Values: 'eco.trashmobdev.trashmobmobile', 'eco.trashmob'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -50,7 +50,7 @@ on:
 
 jobs:
     build:
-        runs-on: macos-14-large
+        runs-on: macos-14
         environment: ${{ inputs.environment }}
         name: iOS Build
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -96,8 +96,8 @@ jobs:
           if: runner.os == 'macOS'
           shell: bash
           run: |
-            sudo xcode-select -s "/Applications/Xcode_16.3.app"
-            echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.3.app" >> $GITHUB_ENV
+            sudo xcode-select -s "/Applications/Xcode_16.2.app"
+            echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.2.app" >> $GITHUB_ENV
 
         - name: Import Code-Signing Certificates
           uses: Apple-Actions/import-codesign-certs@v3

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -96,8 +96,8 @@ jobs:
           if: runner.os == 'macOS'
           shell: bash
           run: |
-            sudo xcode-select -s "/Applications/Xcode_16.2.app"
-            echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.2.app" >> $GITHUB_ENV
+            sudo xcode-select -s "/Applications/Xcode_16.3.app"
+            echo "MD_APPLE_SDK_ROOT=/Applications/Xcode_16.3.app" >> $GITHUB_ENV
 
         - name: Import Code-Signing Certificates
           uses: Apple-Actions/import-codesign-certs@v3

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -90,7 +90,7 @@ jobs:
           run: |
             dotnet nuget locals all --clear
             dotnet workload install maui --ignore-failed-sources
-            dotnet workload install maui-ios --source https://api.nuget.org/v3/index.json
+            dotnet workload install maui-ios --version 9.0.100 --source https://api.nuget.org/v3/index.json
 
         - name: Set XCode Version
           if: runner.os == 'macOS'

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -90,7 +90,7 @@ jobs:
           run: |
             dotnet nuget locals all --clear
             dotnet workload install maui --ignore-failed-sources
-            dotnet workload install maui-ios --version 9.0.100 --source https://api.nuget.org/v3/index.json
+            dotnet workload install maui-ios --version 9.0.200 --source https://api.nuget.org/v3/index.json
 
         - name: Set XCode Version
           if: runner.os == 'macOS'

--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '9.0.x'  # set this to the dotnet version to use
-  DOTNET_VERSION2: '9.0.x'  # set this to the dotnet version to use
+  DOTNET_VERSION: '9.0.100'  # set this to the dotnet version to use
+  DOTNET_VERSION2: '9.0.100'  # set this to the dotnet version to use
   CONFIGURATION: Release      # Values: Debug, Release
   ENVIRONMENT: test         # Values: test, production
   IOS_BUNDLE_ID: 'eco.trashmobdev.trashmobmobile'   # Values: 'eco.trashmobdev.trashmobmobile', 'eco.trashmob'

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -14,8 +14,8 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: '9.0.x'  # set this to the dotnet version to use
-  DOTNET_VERSION2: '9.0.x'  # set this to the dotnet version to use
+  DOTNET_VERSION: '9.0.100'  # set this to the dotnet version to use
+  DOTNET_VERSION2: '9.0.100'  # set this to the dotnet version to use
   CONFIGURATION: Release      # Values: Debug, Release
   ENVIRONMENT: production         # Values: test, production
   ANDROID_BUNDLE_ID: 'eco.trashmob.trashmobmobileapp'   # Values: 'eco.trashmobdev.trashmobmobileapp', 'eco.trashmob'

--- a/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
+++ b/TrashMobMobile/Extensions/ServiceCollectionExtensions.cs
@@ -57,14 +57,18 @@
             services.AddHttpClient($"ServerAPI", client =>
                     client.BaseAddress = new Uri(Settings.ApiBaseUrl))
                 .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>()
+                #if !IOS
                 .AddHttpMessageHandler<SentryHttpMessageHandler>()
+                #endif
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5)) //Set lifetime to five minutes
                 .AddPolicyHandler(GetRetryPolicy());
 
             services.AddHttpClient($"ServerAPI.Anonymous", client =>
                     client.BaseAddress = new Uri(Settings.ApiBaseUrl))
                 .SetHandlerLifetime(TimeSpan.FromMinutes(5)) //Set lifetime to five minutes
+                #if !IOS
                 .AddHttpMessageHandler<SentryHttpMessageHandler>()
+                #endif
                 .AddPolicyHandler(GetRetryPolicy());
 
             return services;

--- a/TrashMobMobile/MauiProgram.cs
+++ b/TrashMobMobile/MauiProgram.cs
@@ -16,8 +16,8 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .UseMauiMaps()
             .UseSharpnadoTabs(loggerEnable: false);
-            
-            builder.ConfigureMauiHandlers(handlers =>
+
+        builder.ConfigureMauiHandlers(handlers =>
             {
 #if ANDROID || IOS || MACCATALYST
                 handlers.AddHandler<Microsoft.Maui.Controls.Maps.Map, CustomMapHandler>();
@@ -33,34 +33,33 @@ public static class MauiProgram
                 fonts.AddFont("googlematerialdesignicons-webfont.ttf", "GoogleMaterialIcons");
             });
 
-            //Sentry AOT SHA initialization issues in ipad air
-            if (DeviceInfo.Name != null && !DeviceInfo.Name.Contains("iPad Air"))
-            {
-                builder.UseSentry(options =>
-                {
-                    // The DSN is the only required setting.
-                    options.Dsn =
-                        "https://4be7fb697cee47ce9554bb64f7d6a476@o4505460799045632.ingest.sentry.io/4505460800225280";
+#if !IOS
+        builder.UseSentry(options =>
+        {
+            // The DSN is the only required setting.
+            options.Dsn =
+                "https://4be7fb697cee47ce9554bb64f7d6a476@o4505460799045632.ingest.sentry.io/4505460800225280";
 
-                    // Use debug mode if you want to see what the SDK is doing.
-                    // Debug messages are written to stdout with Console.Writeline,
-                    // and are viewable in your IDE's debug console or with 'adb logcat', etc.
-                    // This option is not recommended when deploying your application.
-                    options.Debug = false;
+            // Use debug mode if you want to see what the SDK is doing.
+            // Debug messages are written to stdout with Console.Writeline,
+            // and are viewable in your IDE's debug console or with 'adb logcat', etc.
+            // This option is not recommended when deploying your application.
+            options.Debug = false;
 
-                    // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
-                    // We recommend adjusting this value in production.
-                    options.TracesSampleRate = 1.0;
+            // Set TracesSampleRate to 1.0 to capture 100% of transactions for performance monitoring.
+            // We recommend adjusting this value in production.
+            options.TracesSampleRate = 1.0;
 
-                    // Other Sentry options can be set here.
-                    options.CaptureFailedRequests = true;
-                });
-            }
-
+            // Other Sentry options can be set here.
+            options.CaptureFailedRequests = true;
+        });
+#endif
 
         // Services
         builder.Services.AddSingleton<AuthHandler>();
+#if !IOS
         builder.Services.AddTransient<SentryHttpMessageHandler>();
+#endif        
         builder.Services.AddTrashMobServices();
         builder.Services.AddRestClientServices(builder.Configuration);
 


### PR DESCRIPTION
Sentry is throwing an AOT error on application start
This issue is present in latest ios builds so we are going to disable sentry until an update clears this issue.
