### PR TITLE
[Event's Pickup Location] Remove pickup & submit field from create pickup form & fix misalignment

### DIFF
--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.$locationId.edit.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.$locationId.edit.tsx
@@ -16,12 +16,7 @@ import { Textarea } from '@/components/ui/textarea';
 import * as ToolTips from '@/store/ToolTips';
 import * as MapStore from '@/store/MapStore';
 
-import {
-    CreateEventPickupLocation,
-    GetEventPickupLocationById,
-    GetEventPickupLocations,
-    UpdateEventPickupLocation,
-} from '@/services/locations';
+import { GetEventPickupLocationById, GetEventPickupLocations, UpdateEventPickupLocation } from '@/services/locations';
 import { GoogleMap } from '@/components/Map/GoogleMap';
 import { APIProvider, MapMouseEvent, Marker, useMap } from '@vis.gl/react-google-maps';
 import { useAzureMapSearchAddressReverse } from '@/hooks/useAzureMapSearchAddressReverse';
@@ -225,7 +220,7 @@ export const PickupLocationEditForm = (props: PickupLocationEditFormProps) => {
                     name='hasBeenPickedUp'
                     render={({ field }) => (
                         <FormItem className='col-span-3'>
-                            <FormLabel tooltip={ToolTips.PickupLocationHasBeenPickedUp}> </FormLabel>
+                            <FormLabel tooltip={ToolTips.PickupLocationHasBeenPickedUp}>&nbsp;</FormLabel>
                             <FormControl>
                                 <div className='flex items-center space-x-2 h-9'>
                                     <Checkbox id='hasBeenPickedUp' checked={field.value} disabled />
@@ -246,7 +241,7 @@ export const PickupLocationEditForm = (props: PickupLocationEditFormProps) => {
                     name='hasBeenSubmitted'
                     render={({ field }) => (
                         <FormItem className='col-span-3'>
-                            <FormLabel> </FormLabel>
+                            <FormLabel>&nbsp;</FormLabel>
                             <FormControl>
                                 <div className='flex items-center space-x-2 h-9'>
                                     <Checkbox id='hasBeenSubmitted' checked={field.value} disabled />

--- a/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.create.tsx
+++ b/TrashMob/client-app/src/pages/eventsummary/$eventId/pickup-locations.create.tsx
@@ -30,8 +30,6 @@ import { useGetEvent } from '@/hooks/useGetEvent';
 interface CreatePickupLocationFields {
     latitude: number;
     longitude: number;
-    hasBeenSubmitted: boolean;
-    hasBeenPickedUp: boolean;
     name: string;
     notes: string;
 
@@ -46,8 +44,6 @@ interface CreatePickupLocationFields {
 const formSchema = z.object({
     latitude: z.number().optional(),
     longitude: z.number().optional(),
-    hasBeenSubmitted: z.boolean(),
-    hasBeenPickedUp: z.boolean(),
     name: z.string(),
     notes: z.string(),
 
@@ -91,10 +87,7 @@ export const PickupLocationCreateForm = (props: PickupLocationCreateFormProps) =
 
     const form = useForm<CreatePickupLocationFields>({
         resolver: zodResolver(formSchema),
-        defaultValues: {
-            hasBeenPickedUp: false,
-            hasBeenSubmitted: false,
-        },
+        defaultValues: {},
     });
 
     useEffect(() => {
@@ -128,8 +121,14 @@ export const PickupLocationCreateForm = (props: PickupLocationCreateFormProps) =
         body.postalCode = formValues.postalCode ?? '';
         body.latitude = formValues.latitude ?? 0;
         body.longitude = formValues.longitude ?? 0;
-        body.hasBeenPickedUp = formValues.hasBeenPickedUp;
-        body.hasBeenSubmitted = formValues.hasBeenSubmitted;
+
+        /**
+         * Note: At the moment, CreatePickupLocation API accept hasBeenPickedUp and hasBeenSubmitted
+         * in the payload and user can send "true" to mark pickup = true and submit = true
+         * It should not accept hasBeenPickedUp and hasBeenSubmitted in payload
+         */
+        body.hasBeenPickedUp = false;
+        body.hasBeenSubmitted = false;
         body.createdByUserId = currentUser.id;
         mutate(body);
     };
@@ -207,56 +206,6 @@ export const PickupLocationCreateForm = (props: PickupLocationCreateFormProps) =
                             </FormLabel>
                             <FormControl>
                                 <Input {...field} />
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name='hasBeenPickedUp'
-                    render={({ field }) => (
-                        <FormItem className='col-span-3'>
-                            <FormLabel tooltip={ToolTips.PickupLocationHasBeenPickedUp}> </FormLabel>
-                            <FormControl>
-                                <div className='flex items-center space-x-2 h-9'>
-                                    <Checkbox
-                                        id='hasBeenPickedUp'
-                                        checked={field.value}
-                                        onCheckedChange={field.onChange}
-                                    />
-                                    <label
-                                        htmlFor='hasBeenPickedUp'
-                                        className='text-sm mb-0 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
-                                    >
-                                        Picked up?
-                                    </label>
-                                </div>
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-                <FormField
-                    control={form.control}
-                    name='hasBeenSubmitted'
-                    render={({ field }) => (
-                        <FormItem className='col-span-3'>
-                            <FormLabel> </FormLabel>
-                            <FormControl>
-                                <div className='flex items-center space-x-2 h-9'>
-                                    <Checkbox
-                                        id='hasBeenSubmitted'
-                                        checked={field.value}
-                                        onCheckedChange={field.onChange}
-                                    />
-                                    <label
-                                        htmlFor='hasBeenSubmitted'
-                                        className='text-sm mb-0 font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
-                                    >
-                                        Submitted?
-                                    </label>
-                                </div>
                             </FormControl>
                             <FormMessage />
                         </FormItem>


### PR DESCRIPTION
Fix #2155 (Partially, need help on api part)

Note
@joebeernink I think the "Submit pickup locations" is bug. It doesn't seem to update submit value of each pickup location to true.

```
[POST] /pickuplocations/submit/{eventId}
```


<img width="841" alt="image" src="https://github.com/user-attachments/assets/72a50da5-63ad-4b7b-80d8-c1dc76032758" />
