### PR TITLE
E2E: match OAuth authorize path, not ciamlogin.com host

### DIFF
--- a/TrashMob/client-app/e2e/global-setup.ts
+++ b/TrashMob/client-app/e2e/global-setup.ts
@@ -39,7 +39,11 @@ async function loginAndSaveState(
         // Click Sign In
         await page.getByRole('button', { name: /sign in/i }).waitFor({ state: 'visible', timeout: 30000 });
         await page.getByRole('button', { name: /sign in/i }).click();
-        await page.waitForURL(/.*ciamlogin\.com.*/, { timeout: 15000 });
+        // Match on the OAuth authorize path rather than the host — E6 (PR #3535)
+        // flipped the authority from *.ciamlogin.com to auth-dev.trashmob.eco (dev)
+        // and will do the same for auth.trashmob.eco on prod. The `/oauth2/v2.0/authorize`
+        // path is stable across both, so this stays correct through the cutover.
+        await page.waitForURL(/\/oauth2\/v2\.0\/authorize/, { timeout: 15000 });
 
         // Step 1: Email
         await page.fill('input[name="username"]', email);


### PR DESCRIPTION
## Summary

Fixes the E2E test global-setup timeout that's been failing every PR since the E6 dev cutover ([#3535](https://github.com/TrashMob-eco/TrashMob/pull/3535)) — visible on [#3536](https://github.com/TrashMob-eco/TrashMob/pull/3536) and any other PR whose CI includes Playwright.

## The bug

[\`TrashMob/client-app/e2e/global-setup.ts:42\`](TrashMob/client-app/e2e/global-setup.ts#L42):

\`\`\`typescript
await page.waitForURL(/.*ciamlogin\.com.*/, { timeout: 15000 });
\`\`\`

After E6, MSAL redirects sign-in to \`https://auth-dev.trashmob.eco/{tenantId}/oauth2/v2.0/authorize?...\` instead of the canonical \`trashmobecodev.ciamlogin.com\`. The regex never matches → 15s timeout → global setup throws → every test skipped as failed.

Log excerpt from [PR #3536 CI run](https://github.com/TrashMob-eco/TrashMob/actions/runs/30416832465/job/90465070543):

\`\`\`
[global-setup] user login failed: page.waitForURL: Timeout 15000ms exceeded.
  navigated to "https://auth-dev.trashmob.eco/{tenantId}/oauth2/v2.0/authorize?..."
\`\`\`

The browser is on the correct URL. The regex just doesn't match it.

## The fix

Match on the \`/oauth2/v2.0/authorize\` path — that path is identical whether MSAL redirects to \`*.ciamlogin.com\` or a Custom URL Domain like \`auth-dev.trashmob.eco\`. Also survives the eventual prod cutover to \`auth.trashmob.eco\` without needing a follow-up test change.

\`\`\`diff
-        await page.waitForURL(/.*ciamlogin\.com.*/, { timeout: 15000 });
+        // Match on the OAuth authorize path rather than the host — E6 (PR #3535)
+        // flipped the authority from *.ciamlogin.com to auth-dev.trashmob.eco (dev)
+        // and will do the same for auth.trashmob.eco on prod. The \`/oauth2/v2.0/authorize\`
+        // path is stable across both, so this stays correct through the cutover.
+        await page.waitForURL(/\/oauth2\/v2\.0\/authorize/, { timeout: 15000 });
\`\`\`

## Follow-up

After this merges, rebase [#3536](https://github.com/TrashMob-eco/TrashMob/pull/3536) and any other open PRs with failing Playwright checks — CI should then run past global setup.

## Note on the deeper E6 issue

Separately, we're actively investigating an aadg-fleet DNS-hijack problem where some public resolvers route \`auth-dev.trashmob.eco\` to Microsoft's workforce Entra fleet instead of our AFD → CIAM path. That's a MS-side problem (Q&A posted, waiting on response). GitHub Actions runners use Azure infrastructure DNS which resolves to AFD anycast correctly, so E2E should work end-to-end once this test regex is fixed.

## Test plan

- [ ] CI green on this PR
- [ ] Rebase #3536 → CI green
- [ ] Any other open PR with failing Playwright → same treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)