### PR TITLE
E6: revert dev workflow branded-authority env — MS support deadline missed

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -34,12 +34,6 @@ env:
   CUSTOM_DOMAIN_NAME: dev.trashmob.eco
   MANAGED_CERTIFICATE_NAME: dev-trashmob-eco-cert
   STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2
-  # E6 — branded auth authority for TrashMobEcoDev CIAM tenant. Backend +
-  # SPA read AzureAdEntra__Instance from the Container App; when this env
-  # var is passed to containerApp.bicep, the ternary in the bicep
-  # overrides the default trashmobecodev.ciamlogin.com URL. See
-  # Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6 and PR #3528.
-  ENTRA_AUTH_DOMAIN: auth-dev.trashmob.eco
 
 jobs:
   build-and-deploy:
@@ -112,7 +106,6 @@ jobs:
               maxReplicas=3 \
               customDomainName=${{ env.CUSTOM_DOMAIN_NAME }} \
               managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }} \
-              entraAuthDomain=${{ env.ENTRA_AUTH_DOMAIN }} \
               strapiBaseUrl="${{ steps.get-strapi.outputs.strapi_url }}"
 
       # Note: Azure AD Entra External ID configuration is set via environment variables in containerApp.bicep


### PR DESCRIPTION
## Summary

Reverts [PR #3535](https://github.com/TrashMob-eco/TrashMob/pull/3535). Removes \`ENTRA_AUTH_DOMAIN\` env var and the \`entraAuthDomain\` param pass on the dev container-app deploy. Next deploy restores \`AzureAdEntra__Instance\` to the default \`https://trashmobecodev.ciamlogin.com/\` ternary value, which **unblocks dev sign-in** for the ~4-of-7 major public resolvers whose DNS response was sending browsers to the buggy aadg fleet.

## Why now

The underlying aadg Custom URL Domain propagation bug was filed with Microsoft support on **2026-08-01** (Sev B, upgraded to \$100/mo Standard plan specifically to open the case). It has now been **17 business days** with **no substantive engineering response**. Follow-up on 2026-08-15 set an explicit deadline of **2026-08-18 6pm PT** for engineering acknowledgement — that deadline has passed.

Meanwhile, we need to be able to deploy other changes to production, and the E2E test suite has been blocked in CI on the same bug. Reverting the customer-facing cutover unblocks both.

## What's preserved

Everything E6-infrastructure-wise stays in place:

- ✅ Azure Front Door scaffold (PR #3527)
- ✅ Container App bicep \`entraAuthDomain\` param (PR #3528)
- ✅ Dev Front Door workflow (PR #3530)
- ✅ DNS records for \`auth-dev.trashmob.eco\` (A records + \`_dnsauth\` TXT — PRs #3531/#3532/#3534)
- ✅ Entra Custom URL Domain association on TrashMobEcoDev tenant (still Verified + Associated)
- ✅ AFD custom domain + managed cert (still \`domainValidationState=Approved\`, \`deploymentStatus=Succeeded\`)

**The failing state remains reproducible from Microsoft's side** via the request-ID captures already in the support case. This revert only stops the customer-facing cutover.

## Companion draft PR

A draft PR re-adds the two removed lines: **PR #{FILL-IN-AFTER-CREATION}**. That PR is intended to be merged if/when Microsoft resolves the aadg routing bug — either to complete the E6 cutover (if actually fixed) or to quickly re-establish the failing state for continued diagnosis.

## Test plan

- [ ] Merge → dev container-app workflow runs
- [ ] After deploy, \`GET https://dev.trashmob.eco/api/v2/config\` returns \`authorityDomain: "trashmobecodev.ciamlogin.com"\` and \`authority: "https://trashmobecodev.ciamlogin.com/{tenantId}"\` (pre-E6 state)
- [ ] Browser sign-in on dev.trashmob.eco works from any resolver (previously broke on ~4 of 7)
- [ ] E2E Playwright tests pass in CI on subsequent PRs (test regex \`/.*ciamlogin\.com.*/\` matches again post-revert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)