### PR TITLE
E6: re-apply dev workflow branded-authority env (companion to #3539 revert)

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -34,6 +34,12 @@ env:
   CUSTOM_DOMAIN_NAME: dev.trashmob.eco
   MANAGED_CERTIFICATE_NAME: dev-trashmob-eco-cert
   STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-dev-westus2
+  # E6 — branded auth authority for TrashMobEcoDev CIAM tenant. Backend +
+  # SPA read AzureAdEntra__Instance from the Container App; when this env
+  # var is passed to containerApp.bicep, the ternary in the bicep
+  # overrides the default trashmobecodev.ciamlogin.com URL. See
+  # Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6 and PR #3528.
+  ENTRA_AUTH_DOMAIN: auth-dev.trashmob.eco
 
 jobs:
   build-and-deploy:
@@ -111,6 +117,7 @@ jobs:
               maxReplicas=3 \
               customDomainName=${{ env.CUSTOM_DOMAIN_NAME }} \
               managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }} \
+              entraAuthDomain=${{ env.ENTRA_AUTH_DOMAIN }} \
               strapiBaseUrl="${{ steps.get-strapi.outputs.strapi_url }}"
 
       # Note: Azure AD Entra External ID configuration is set via environment variables in containerApp.bicep


### PR DESCRIPTION
## Summary — DRAFT

Companion to [PR #3539](https://github.com/TrashMob-eco/TrashMob/pull/3539) (the revert). Re-adds \`ENTRA_AUTH_DOMAIN: auth-dev.trashmob.eco\` env var and the \`entraAuthDomain\` param pass on the dev container-app deploy. Next deploy after merge restores \`AzureAdEntra__Instance\` to the branded value and re-establishes whichever behavior Microsoft's aadg fleet is currently exhibiting.

**Do not merge yet.** Merge only when one of these conditions holds:

1. **Microsoft support confirms the aadg propagation bug is fixed** — we merge to complete the E6 dev cutover.
2. **Microsoft asks us to reproduce the failing state** — we merge briefly to re-establish live failure for diagnostic captures, then re-revert.
3. **We decide to explore an alternative auth-domain pattern** — we merge and test whether a different config avoids the bug.

## Why draft, not "ready when needed"

Keeping this in-repo as a merge-ready PR means the moment Microsoft moves, we're one click away from reproducing the state. No hunting through git history for the exact lines, no re-typing the env var. Also serves as a visible reminder in the PR list that E6 is parked but not abandoned.

## About the PR diff

This branch is currently based on \`dev/joe/e6-revert-branded-authority-dev\` (the branch behind PR #3539). Until #3539 merges to main, GitHub may show 2 commits ([revert] + [re-add]) with a **cumulatively empty file diff** — that's expected.

Once #3539 merges to main:
- GitHub recomputes the merge base to include the revert
- This PR's effective diff collapses to just the re-add commit (7 lines back into \`.github/workflows/container_ca-tm-dev-westus2.yml\`)
- If #3539 was squash-merged, a manual rebase may be needed (per the [stacked-phase-branches-rebase-on-merge](https://github.com/TrashMob-eco/TrashMob/tree/main) memory pattern — reset to origin/main and cherry-pick only the re-add commit).

## What NOT to touch

The rest of the E6 infrastructure (AFD scaffold, Container App bicep param, DNS records, Entra Custom URL Domain association, AFD custom domain + managed cert) all remain in place after #3539 merges. This PR only re-flips the single env var that controls the customer-facing authority.

## Ref

- Root E6 checklist: [\`Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md\`](Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md) §E6
- Original flip: PR #3535
- Revert: PR #3539

🤖 Generated with [Claude Code](https://claude.com/claude-code)