### PR TITLE
CI: apply EF migrations before dev container-app deploy

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -84,6 +84,78 @@ jobs:
             echo "strapi_url=" >> $GITHUB_OUTPUT
           fi
 
+      # ─── EF migrations (before container deploy) ──────────────────────────
+      # Applies any pending EF Core migrations to the dev SQL DB before the
+      # new container revision goes live. Prevents the class of bug where a
+      # merged PR adds a migration in code but the schema never actually gets
+      # applied — the exact failure mode that surfaced on 2026-08-19 when
+      # the RBAC refactor's AddRolesAndUserRoles migration had never run and
+      # every authenticated request threw "Invalid object name 'UserRoles'."
+      #
+      # Order: runs after container build/push and Strapi lookup, before the
+      # bicep deploy of the new revision. A migration failure aborts the
+      # workflow with the deploy skipped, so we never ship code that assumes
+      # a schema the DB doesn't have.
+      #
+      # SQL access: the runner opens a per-run firewall pinhole for its own
+      # public IP, fetches the connection string from Key Vault (workflow SP
+      # already has KV read via the pattern used by the Azure Maps step), and
+      # tears the firewall rule down in an always-run cleanup step.
+
+      - name: Setup .NET for EF migrations
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Add runner IP to SQL firewall (temp)
+        id: sql-fw
+        run: |
+          RUNNER_IP=$(curl -sS https://api.ipify.org)
+          RULE_NAME="ci-migration-${GITHUB_RUN_ID}"
+          echo "Adding firewall rule '$RULE_NAME' for $RUNNER_IP"
+          az sql server firewall-rule create \
+            --name "$RULE_NAME" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --server "sql-tm-dev-westus2" \
+            --start-ip-address "$RUNNER_IP" \
+            --end-ip-address "$RUNNER_IP" \
+            -o none
+          echo "rule_name=$RULE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Fetch DB connection string from Key Vault
+        id: db-conn
+        run: |
+          CONN=$(az keyvault secret show \
+            --vault-name "${{ env.KEY_VAULT_NAME }}" \
+            --name "TMDBServerConnectionString" \
+            --query value -o tsv)
+          echo "::add-mask::$CONN"
+          echo "value=$CONN" >> $GITHUB_OUTPUT
+
+      - name: Apply EF migrations to dev DB
+        env:
+          # The app reads the connection string from the top-level
+          # TMDBServerConnectionString config key (see TrashMob/Program.cs:258).
+          # `dotnet ef` picks it up via IConfiguration during design-time build.
+          TMDBServerConnectionString: ${{ steps.db-conn.outputs.value }}
+        run: |
+          dotnet tool install --global dotnet-ef --version 10.0.*
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          dotnet ef database update \
+            --project TrashMob.Shared \
+            --startup-project TrashMob \
+            --context MobDbContext
+
+      - name: Remove runner IP from SQL firewall (cleanup)
+        if: always() && steps.sql-fw.outputs.rule_name != ''
+        run: |
+          az sql server firewall-rule delete \
+            --name "${{ steps.sql-fw.outputs.rule_name }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --server "sql-tm-dev-westus2" \
+            -o none || true
+      # ─── end EF migrations ────────────────────────────────────────────────
+
       - name: Deploy to Azure Container Apps
         run: |
           SUBSCRIPTION_ID="${{ secrets.AZURE_SUBSCRIPTION_ID }}"


### PR DESCRIPTION
## Summary

Adds an EF-migration step to the dev container-app deploy workflow so a merged PR with a new migration can never again ship code that assumes a schema the DB doesn't have.

**Motivation:** on 2026-08-19, the `AddRolesAndUserRoles` migration (in tree since 2026-07-03 from the RBAC refactor) had never actually been applied to the dev SQL database. Every authenticated request that hit the role-lookup path returned HTTP 500 with `Invalid object name 'UserRoles'`. Discovered only when the E6 revert (#3539) landed and testing resumed on ciamlogin.com — nothing else exercised the branded-authority + role-check codepath during the E6 rollout window.

## What changed

One file: [\`.github/workflows/container_ca-tm-dev-westus2.yml\`](.github/workflows/container_ca-tm-dev-westus2.yml). Five new steps inserted between "Get Strapi FQDN" and "Deploy to Azure Container Apps":

1. **Setup .NET 10** on the runner
2. **Add per-run SQL firewall pinhole** for the runner's public IP (rule name = \`ci-migration-${GITHUB_RUN_ID}\` — parallel runs can't collide)
3. **Fetch \`TMDBServerConnectionString\` from Key Vault** — workflow SP already has KV secret access via the same pattern the existing "Grant Azure Maps Access via RBAC" step uses
4. **\`dotnet ef database update\`** with the connection string as an env var (config key is top-level \`TMDBServerConnectionString\`, not \`ConnectionStrings:MobDbContext\` — see [\`TrashMob/Program.cs:258\`](TrashMob/Program.cs#L258))
5. **Tear down the firewall rule** with \`if: always()\` so cleanup runs even on migration failure

## Order rationale

Migrations run **before** the container-app deploy step. A migration failure aborts the workflow with the deploy skipped — never ship code that assumes an unapplied schema. That's exactly what happened on Aug 19 and is what this PR prevents recurring.

## Failure modes handled

| Scenario | Behavior |
|---|---|
| Migration fails | Deploy skipped, firewall cleaned up, workflow fails visibly. Fix migration or DB state manually, rerun. |
| Firewall step succeeds, migration fails for any reason | Cleanup still runs (\`if: always()\`) |
| Parallel dev deploys | Unique \`GITHUB_RUN_ID\` in rule name prevents collision. \`concurrency: cancel-in-progress\` at the top of the workflow means only one migration runs at a time in practice. |
| \`az keyvault secret show\` denied | Workflow fails at step 3, deploy skipped. Fix: grant workflow SP \`Key Vault Secrets User\` on the dev KV. (Expected to work out of the box — the workflow already writes secrets via \`az keyvault secret set\`.) |

## Scope + follow-up

- **Dev only** in this PR. Prod (\`release_ca-tm-pr-westus2.yml\`) is a symmetric follow-up you'd merge to \`release\` when ready. Same shape, different resource-group + SQL server + KV names.
- **Container App Jobs** (daily / hourly) do NOT need their own migration step — they share the DB and pick up whatever schema this workflow applied.
- **Runtime cost:** ~30-60s added (setup-dotnet + tool install + \`dotnet ef database update\` build). If that becomes a concern later, the \`--idempotent\` script approach is faster but harder to read.

## Test plan

- [ ] Merge → workflow runs → migration step succeeds → deploy runs → dev sign-in works (no more 500 on role lookup)
- [ ] Add a trivial no-op migration on a scratch branch to verify the step actually applies new migrations end-to-end
- [ ] Simulate migration failure (e.g. bad SQL in a scratch migration) and confirm deploy step is skipped
- [ ] Confirm firewall rule cleanup runs on both success and failure paths

Ref: PR #3538 (RBAC refactor merge), PR #3539 (E6 revert), Program.cs:258, TrashMob.Shared/Migrations/20260703202044_AddRolesAndUserRoles.cs

🤖 Generated with [Claude Code](https://claude.com/claude-code)