### PR TITLE
CI: dotnet restore before EF migration step (fixes assets file error)

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -141,6 +141,11 @@ jobs:
         run: |
           dotnet tool install --global dotnet-ef --version 10.0.*
           export PATH="$PATH:$HOME/.dotnet/tools"
+          # `dotnet ef database update` runs a design-time build of the startup
+          # project. The container-build-push step above built inside a Docker
+          # container so no restore artifacts exist on the runner filesystem —
+          # explicit restore is required before ef can build.
+          dotnet restore TrashMob/TrashMob.csproj
           dotnet ef database update \
             --project TrashMob.Shared \
             --startup-project TrashMob \


### PR DESCRIPTION
## Summary

Fixes the failure on [PR #3541](https://github.com/TrashMob-eco/TrashMob/pull/3541)'s first workflow run ([run 32218457796](https://github.com/TrashMob-eco/TrashMob/actions/runs/32218457796)):

\`\`\`
error: Assets file '/home/runner/work/TrashMob/TrashMob/TrashMob.Shared/obj/project.assets.json' not found.
Run a NuGet package restore to generate this file.
\`\`\`

**Root cause:** \`dotnet ef database update\` does a design-time build of the startup project, which requires NuGet packages to be restored. The \`container-build-push\` step above builds inside a Docker container — that build is isolated from the runner's dotnet workspace, so no restore artifacts exist on the runner filesystem.

**Fix:** explicit \`dotnet restore TrashMob/TrashMob.csproj\` before the ef command. Restore graph includes \`TrashMob.Shared\` as a transitive project reference, so a single restore call covers both projects.

## What worked correctly on the failed run

Everything else about the migration step, actually. This is the good news — the design of the wrapper is sound, the fix is just the one missing prep step:

- ✓ Setup .NET 10 on runner
- ✓ Firewall pinhole added
- ✓ **Key Vault secret fetch succeeded** (SP permissions are fine — no additional role grants needed)
- ✗ Apply EF migrations (build failure — this PR's fix)
- ✓ Firewall pinhole cleanup ran despite migration failure
- ✓ **Deploy step correctly skipped** — didn't ship code with unapplied migrations

## Diff

\`\`\`diff
       - name: Apply EF migrations to dev DB
         env:
           TMDBServerConnectionString: \${{ steps.db-conn.outputs.value }}
         run: |
           dotnet tool install --global dotnet-ef --version 10.0.*
           export PATH="\$PATH:\$HOME/.dotnet/tools"
+          # \`dotnet ef database update\` runs a design-time build of the startup
+          # project. The container-build-push step above built inside a Docker
+          # container so no restore artifacts exist on the runner filesystem —
+          # explicit restore is required before ef can build.
+          dotnet restore TrashMob/TrashMob.csproj
           dotnet ef database update              --project TrashMob.Shared              --startup-project TrashMob              --context MobDbContext
\`\`\`

5 lines added (4 comment + 1 command).

## Test plan

- [ ] Merge → next dev workflow run gets past the migration step
- [ ] Migration successfully applies \`AddRolesAndUserRoles\` (and any other pending) to \`db-tm-dev-westus2\`
- [ ] Deploy step runs after migration succeeds
- [ ] Dev sign-in now works (no more \`Invalid object name 'UserRoles'\` 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)