### PR TITLE
CI: use TMDBAdminConnectionString for EF migrations (DDL rights)

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -122,12 +122,17 @@ jobs:
             -o none
           echo "rule_name=$RULE_NAME" >> $GITHUB_OUTPUT
 
-      - name: Fetch DB connection string from Key Vault
+      - name: Fetch admin DB connection string from Key Vault
         id: db-conn
         run: |
+          # Use TMDBAdminConnectionString (dbadmin — has DDL rights), NOT
+          # TMDBServerConnectionString (trashmob_app — DML only, used by the
+          # running app at runtime). Attempted TMDBServerConnectionString on
+          # 2026-08-19 run 32218927181 failed with "CREATE TABLE permission
+          # denied" halfway through AddProspectContactsAndDropLegacyContactFields.
           CONN=$(az keyvault secret show \
             --vault-name "${{ env.KEY_VAULT_NAME }}" \
-            --name "TMDBServerConnectionString" \
+            --name "TMDBAdminConnectionString" \
             --query value -o tsv)
           echo "::add-mask::$CONN"
           echo "value=$CONN" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Fixes the second failure on the CI-migration wrapper (previous failure was #3542's restore fix):

**Run [32218927181](https://github.com/TrashMob-eco/TrashMob/actions/runs/32218927181)** got past the missing-restore issue, applied \`AddRolesAndUserRoles\` and several other migrations successfully, then failed halfway through \`AddProspectContactsAndDropLegacyContactFields\`:

\`\`\`
Microsoft.Data.SqlClient.SqlException: CREATE TABLE permission denied in database 'db-tm-dev-westus2'.
Error Number: 262, State: 1, Class: 14
\`\`\`

## Root cause

Wrong secret picked in [#3541](https://github.com/TrashMob-eco/TrashMob/pull/3541). The KV has **two** DB connection strings:

| Secret | User | Rights | Purpose |
|---|---|---|---|
| \`TMDBServerConnectionString\` | \`trashmob_app\` | DML only (SELECT/INSERT/UPDATE/DELETE) | Runtime — used by the running app |
| \`TMDBAdminConnectionString\` | \`dbadmin\` | Full (DDL + DML) | **Migrations, admin ops** |

Both were provisioned on 2026-02-25 by \`setupdev.ps1\`. This is the correct pattern — runtime code shouldn't have schema-altering rights. I just picked the wrong secret name when writing #3541.

## Fix

One-line change: swap \`TMDBServerConnectionString\` → \`TMDBAdminConnectionString\` in the KV fetch step, plus a comment recording the reason so a future editor doesn't "fix" it back to look like the runtime one.

\`\`\`diff
-      - name: Fetch DB connection string from Key Vault
+      - name: Fetch admin DB connection string from Key Vault
         id: db-conn
         run: |
+          # Use TMDBAdminConnectionString (dbadmin — has DDL rights), NOT
+          # TMDBServerConnectionString (trashmob_app — DML only, used by the
+          # running app at runtime).
           CONN=\$(az keyvault secret show              --vault-name "\${{ env.KEY_VAULT_NAME }}" -            --name "TMDBServerConnectionString" +            --name "TMDBAdminConnectionString"              --query value -o tsv)
\`\`\`

The env var passed to \`dotnet ef\` stays as \`TMDBServerConnectionString\` — that's the config key name the app expects, unrelated to the KV secret name. EF just needs A connection string; using the admin one gives it the rights it needs to actually apply schema changes.

## What we learned from the previous run (worth keeping in mind)

The successful portion of that run confirmed:
- ✓ KV secret fetch works (dev SP has appropriate KV read)
- ✓ SQL firewall pinhole opens + tears down cleanly
- ✓ \`dotnet ef database update\` connects and applies migrations
- ✓ \`AddRolesAndUserRoles\` (the migration tonight was originally about) **did apply successfully** before the ProspectContacts one failed

So dev sign-in should already be unblocked from that partial run — the RBAC tables exist. This PR completes the tail of migrations that couldn't apply.

## Test plan

- [ ] Merge → workflow runs → migration step gets all the way through
- [ ] All 10 or so pending migrations applied to \`db-tm-dev-westus2\`
- [ ] Deploy step runs after migration succeeds
- [ ] Firewall cleanup runs
- [ ] Dev sign-in works (double-check even though RBAC portion already applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)