### PR TITLE
CI: extract dev DB migrations to standalone workflow mirroring prod

### DIFF
--- a/.github/workflows/container_ca-tm-dev-westus2.yml
+++ b/.github/workflows/container_ca-tm-dev-westus2.yml
@@ -84,87 +84,10 @@ jobs:
             echo "strapi_url=" >> $GITHUB_OUTPUT
           fi
 
-      # ─── EF migrations (before container deploy) ──────────────────────────
-      # Applies any pending EF Core migrations to the dev SQL DB before the
-      # new container revision goes live. Prevents the class of bug where a
-      # merged PR adds a migration in code but the schema never actually gets
-      # applied — the exact failure mode that surfaced on 2026-08-19 when
-      # the RBAC refactor's AddRolesAndUserRoles migration had never run and
-      # every authenticated request threw "Invalid object name 'UserRoles'."
-      #
-      # Order: runs after container build/push and Strapi lookup, before the
-      # bicep deploy of the new revision. A migration failure aborts the
-      # workflow with the deploy skipped, so we never ship code that assumes
-      # a schema the DB doesn't have.
-      #
-      # SQL access: the runner opens a per-run firewall pinhole for its own
-      # public IP, fetches the connection string from Key Vault (workflow SP
-      # already has KV read via the pattern used by the Azure Maps step), and
-      # tears the firewall rule down in an always-run cleanup step.
-
-      - name: Setup .NET for EF migrations
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: Add runner IP to SQL firewall (temp)
-        id: sql-fw
-        run: |
-          RUNNER_IP=$(curl -sS https://api.ipify.org)
-          RULE_NAME="ci-migration-${GITHUB_RUN_ID}"
-          echo "Adding firewall rule '$RULE_NAME' for $RUNNER_IP"
-          az sql server firewall-rule create \
-            --name "$RULE_NAME" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --server "sql-tm-dev-westus2" \
-            --start-ip-address "$RUNNER_IP" \
-            --end-ip-address "$RUNNER_IP" \
-            -o none
-          echo "rule_name=$RULE_NAME" >> $GITHUB_OUTPUT
-
-      - name: Fetch admin DB connection string from Key Vault
-        id: db-conn
-        run: |
-          # Use TMDBAdminConnectionString (dbadmin — has DDL rights), NOT
-          # TMDBServerConnectionString (trashmob_app — DML only, used by the
-          # running app at runtime). Attempted TMDBServerConnectionString on
-          # 2026-08-19 run 32218927181 failed with "CREATE TABLE permission
-          # denied" halfway through AddProspectContactsAndDropLegacyContactFields.
-          CONN=$(az keyvault secret show \
-            --vault-name "${{ env.KEY_VAULT_NAME }}" \
-            --name "TMDBAdminConnectionString" \
-            --query value -o tsv)
-          echo "::add-mask::$CONN"
-          echo "value=$CONN" >> $GITHUB_OUTPUT
-
-      - name: Apply EF migrations to dev DB
-        env:
-          # The app reads the connection string from the top-level
-          # TMDBServerConnectionString config key (see TrashMob/Program.cs:258).
-          # `dotnet ef` picks it up via IConfiguration during design-time build.
-          TMDBServerConnectionString: ${{ steps.db-conn.outputs.value }}
-        run: |
-          dotnet tool install --global dotnet-ef --version 10.0.*
-          export PATH="$PATH:$HOME/.dotnet/tools"
-          # `dotnet ef database update` runs a design-time build of the startup
-          # project. The container-build-push step above built inside a Docker
-          # container so no restore artifacts exist on the runner filesystem —
-          # explicit restore is required before ef can build.
-          dotnet restore TrashMob/TrashMob.csproj
-          dotnet ef database update \
-            --project TrashMob.Shared \
-            --startup-project TrashMob \
-            --context MobDbContext
-
-      - name: Remove runner IP from SQL firewall (cleanup)
-        if: always() && steps.sql-fw.outputs.rule_name != ''
-        run: |
-          az sql server firewall-rule delete \
-            --name "${{ steps.sql-fw.outputs.rule_name }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --server "sql-tm-dev-westus2" \
-            -o none || true
-      # ─── end EF migrations ────────────────────────────────────────────────
+      # Note: EF Core migrations are applied by a separate workflow,
+      # main_db-migrations.yml, mirroring the prod pattern in
+      # release_db-migrations.yml. That workflow is triggered on the same
+      # push if the push includes migration file changes.
 
       - name: Deploy to Azure Container Apps
         run: |

--- a/.github/workflows/main_db-migrations.yml
+++ b/.github/workflows/main_db-migrations.yml
@@ -1,0 +1,153 @@
+# Runs EF Core database migrations against the dev Azure SQL database.
+# Triggered automatically on push to main (when migration-related files change)
+# or manually via workflow_dispatch.
+#
+# Mirrors release_db-migrations.yml (prod). Same shape, dev-suffixed resources,
+# no environment approval gate (dev doesn't need one).
+#
+# Safety features:
+# - Temporarily opens SQL firewall for the GitHub runner IP, then removes it
+# - Uses TMDBAdminConnectionString (dbadmin, DDL rights) with fallback to
+#   TMDBServerConnectionString for the edge case where a fresh dev environment
+#   hasn't run the least-privilege setup yet
+# - Lists pending migrations before applying (visible skip if none)
+# - concurrency: cancel-in-progress: false — never kill a partial migration
+
+name: TrashMobDev - Database Migrations
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'TrashMob.Shared/Migrations/**'
+      - 'TrashMob.Shared/Persistence/MobDbContext.cs'
+      - '.github/workflows/main_db-migrations.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: db-migrations-dev
+  cancel-in-progress: false  # Never cancel in-progress migrations
+
+env:
+  DOTNET_VERSION: '10.0.x'
+  SQL_SERVER_NAME: sql-tm-dev-westus2
+  SQL_DATABASE_NAME: db-tm-dev-westus2
+  RESOURCE_GROUP: rg-trashmob-dev-westus2
+  KEY_VAULT_NAME: kv-tm-dev-westus2
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    environment: test
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Install EF Core tools
+        run: dotnet tool install --global dotnet-ef
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get runner public IP
+        id: runner-ip
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          echo "ip=$RUNNER_IP" >> $GITHUB_OUTPUT
+          echo "Runner IP: $RUNNER_IP"
+
+      - name: Add runner IP to SQL firewall
+        run: |
+          echo "Adding temporary firewall rule for GitHub runner..."
+          az sql server firewall-rule create \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --server ${{ env.SQL_SERVER_NAME }} \
+            --name "github-actions-runner-${{ github.run_id }}" \
+            --start-ip-address ${{ steps.runner-ip.outputs.ip }} \
+            --end-ip-address ${{ steps.runner-ip.outputs.ip }}
+          echo "Firewall rule added. Waiting 10 seconds for propagation..."
+          sleep 10
+
+      - name: Get admin connection string from Key Vault
+        id: get-connection-string
+        run: |
+          # Use the admin connection string for schema migrations.
+          # Falls back to TMDBServerConnectionString if the admin secret doesn't exist yet
+          # (before least-privilege setup has been run).
+          CONNECTION_STRING=$(az keyvault secret show \
+            --vault-name ${{ env.KEY_VAULT_NAME }} \
+            --name TMDBAdminConnectionString \
+            --query value \
+            -o tsv 2>/dev/null) || \
+          CONNECTION_STRING=$(az keyvault secret show \
+            --vault-name ${{ env.KEY_VAULT_NAME }} \
+            --name TMDBServerConnectionString \
+            --query value \
+            -o tsv)
+          echo "::add-mask::$CONNECTION_STRING"
+          echo "connection_string=$CONNECTION_STRING" >> $GITHUB_OUTPUT
+
+      - name: Restore and build
+        run: |
+          dotnet restore TrashMob.sln
+          dotnet build TrashMob/TrashMob.csproj --no-restore
+
+      - name: List pending migrations
+        run: |
+          echo "Checking for pending migrations..."
+          dotnet ef migrations list \
+            --project TrashMob.Shared/TrashMob.Shared.csproj \
+            --startup-project TrashMob/TrashMob.csproj \
+            --connection "${{ steps.get-connection-string.outputs.connection_string }}" \
+            --no-build \
+            2>&1 | tee /tmp/migrations-list.txt
+
+          # Count pending (not yet applied) migrations
+          PENDING=$(grep -c "(Pending)" /tmp/migrations-list.txt || true)
+          echo "Pending migrations: $PENDING"
+          echo "pending_count=$PENDING" >> $GITHUB_OUTPUT
+        id: list-migrations
+
+      - name: Apply migrations
+        if: steps.list-migrations.outputs.pending_count != '0'
+        run: |
+          echo "Applying ${{ steps.list-migrations.outputs.pending_count }} pending migration(s)..."
+          dotnet ef database update \
+            --project TrashMob.Shared/TrashMob.Shared.csproj \
+            --startup-project TrashMob/TrashMob.csproj \
+            --connection "${{ steps.get-connection-string.outputs.connection_string }}" \
+            --no-build \
+            --verbose
+          echo "Migrations applied successfully."
+
+      - name: Skip message
+        if: steps.list-migrations.outputs.pending_count == '0'
+        run: echo "No pending migrations to apply."
+
+      - name: Remove runner IP from SQL firewall
+        if: always()
+        run: |
+          echo "Removing temporary firewall rule..."
+          az sql server firewall-rule delete \
+            --resource-group ${{ env.RESOURCE_GROUP }} \
+            --server ${{ env.SQL_SERVER_NAME }} \
+            --name "github-actions-runner-${{ github.run_id }}" \
+            --yes 2>/dev/null || echo "Firewall rule already removed or not found."
+
+      - name: Logout from Azure
+        if: always()
+        run: az logout


### PR DESCRIPTION
## Summary

Aligns the dev DB migration pipeline to the canonical prod pattern in [\`release_db-migrations.yml\`](.github/workflows/release_db-migrations.yml).

Tonight's three-PR discovery cycle ([#3541](https://github.com/TrashMob-eco/TrashMob/pull/3541) wrapper design, [#3542](https://github.com/TrashMob-eco/TrashMob/pull/3542) restore fix, [#3543](https://github.com/TrashMob-eco/TrashMob/pull/3543) admin-conn fix) rediscovered every design decision already made by the prod workflow. This PR retires my inline block and stands up a proper standalone workflow. Result: dev and prod share the same shape.

## What changed

- **New:** [\`.github/workflows/main_db-migrations.yml\`](.github/workflows/main_db-migrations.yml) — direct mirror of \`release_db-migrations.yml\` with dev-suffixed resource names. Triggers only on migration file changes (not every code push).
- **Removed:** the inline migration block from [\`container_ca-tm-dev-westus2.yml\`](.github/workflows/container_ca-tm-dev-westus2.yml). Container deploys stop coupling to migration state.

## Structure (identical to prod)

1. Setup .NET → install \`dotnet-ef\`
2. \`az login\` (OIDC)
3. Get runner IP → open SQL firewall pinhole → 10s propagation wait
4. Fetch \`TMDBAdminConnectionString\` from Key Vault (fallback to \`TMDBServerConnectionString\` for edge case where least-privilege setup hasn't run)
5. \`dotnet restore TrashMob.sln\` then \`dotnet build ... --no-restore\`
6. \`dotnet ef migrations list\` → count pending → set output
7. \`dotnet ef database update\` (gated on \`pending_count != '0'\`)
8. Firewall rule cleanup with \`if: always()\`
9. \`az logout\`

**\`concurrency: cancel-in-progress: false\`** — never kill a partially-applied migration mid-flight. Same as prod.

## What you gain

- **One pattern to reason about.** Dev and prod migrations look identical.
- **No wasted CI minutes.** Container-app deploys no longer install .NET + build the project just to run migrations that don't exist.
- **Visible skip when there's nothing to migrate.** The "List pending migrations" + gated "Apply migrations" pattern surfaces no-op runs clearly.
- **Path-filtered triggers.** Migrations only run when migration files actually change. Ordinary code pushes are untouched.

## What you lose (and how to mitigate if it bites)

**Migration failure no longer blocks the container-app deploy in the same run.** If a migration fails AND the container deploys anyway, the app starts against a stale schema and 500s on affected code paths — the exact scenario that motivated all of this. Same limitation as prod today.

Prod's mitigation is that the migration workflow is much shorter than the container-app deploy, so in practice migrations finish first. If this proves fragile in practice, add an explicit \`workflow_run\` trigger on the container-app deploy to gate on migration success.

## Test plan

- [ ] Merge → workflow file is on \`main\` but nothing triggers it (no migration path changes in this PR)
- [ ] Manually trigger via \`workflow_dispatch\` → \`pending_count\` reports 0 (all migrations applied by tonight's earlier runs) → "No pending migrations to apply."
- [ ] Next PR that touches \`TrashMob.Shared/Migrations/**\` triggers both this workflow AND \`container_ca-tm-dev-westus2.yml\`. Migrations apply first (shorter workflow), then container deploy runs.

## Follow-ups

- If we hit ordering issues in practice, add \`workflow_run\` dependency
- Consider adding a \`dev\` GitHub environment (matches prod's \`production\` environment) — no gate needed on dev but establishes symmetry

Ref: PRs [#3541](https://github.com/TrashMob-eco/TrashMob/pull/3541), [#3542](https://github.com/TrashMob-eco/TrashMob/pull/3542), [#3543](https://github.com/TrashMob-eco/TrashMob/pull/3543). Canonical pattern: [\`release_db-migrations.yml\`](.github/workflows/release_db-migrations.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)