### PR TITLE
Fix crash: MainActivity LaunchMode SingleTop -> SingleTask

### DIFF
--- a/TrashMobMobile/Platforms/Android/MainActivity.cs
+++ b/TrashMobMobile/Platforms/Android/MainActivity.cs
@@ -6,7 +6,14 @@
     using Microsoft.Identity.Client;
 
 #pragma warning disable SA1118
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
+    // LaunchMode must be SingleTask, not SingleTop. SingleTop only dedupes when the
+    // existing instance is at the top of the *same* task; some OEM launchers (OnePlus/
+    // OxygenOS observed in Sentry) start a new task when the app icon is tapped after
+    // backgrounding, spinning up a second MainActivity while the first is still alive.
+    // That second instance's Window collides with the MAUI Window already bound to the
+    // first, throwing "This window is already associated with an active Activity."
+    // SingleTask guarantees a single instance across all tasks/launch paths.
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask,
         ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode |
                                ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
 #pragma warning restore SA1118


### PR DESCRIPTION
## Summary

Fixes a production crash reported in Sentry (release 2.11.1214, OnePlus 8 Pro / Android 11, unhandled):

```
System.InvalidOperationException: This window is already associated with an active Activity (TrashMobMobile.MainActivity). Please override CreateWindow on TrashMobMobile.App to add support for multiple activities https://aka.ms/maui-docs-create-window or set the LaunchMode to SingleTop on TrashMobMobile.MainActivity.
```

## Investigation

`MainActivity` was already `LaunchMode.SingleTop` — the fix the exception message itself suggests — so the direct suggestion didn't apply.

**Root cause:** `SingleTop` only dedupes an Activity when the existing instance is at the top of the *same* task. It does not protect against a *new task* being created — which some OEM launchers (OnePlus/OxygenOS, per the Sentry device tag) do when the app icon is tapped after backgrounding, rather than resuming from Recents. That spins up a second `MainActivity` instance while the first is still alive in memory, and the new instance's `Window` collides with the MAUI `Window` already bound to the first.

**Ruled out:**
- `MsalActivity` (the MSAL auth broker activity) — it's a transient `BrowserTabActivity` that forwards auth callbacks and finishes immediately; it never touches the MAUI `Window`.
- Notification-based launches — no `PendingIntent` targeting `MainActivity` exists in the codebase.

## Fix

`LaunchMode.SingleTask` guarantees Android never creates a second instance of `MainActivity` regardless of task or launch path — Android routes the intent to the existing instance via `OnNewIntent` and brings its task to the foreground instead of creating a new Activity+Window.

TrashMobMobile is a single-Activity Shell app with no multi-window requirement, so `SingleTask` is the right fit over the alternate fix (implementing `CreateWindow` for multi-window support, which doesn't apply here).

```diff
-    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop,
+    [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTask,
```

Plus a comment explaining the reasoning so a future editor doesn't revert this back to `SingleTop`.

## Verification

**Not verified with a full local build in this session** — `dotnet restore` hit a transient NuGet TLS handshake failure (`NU1301`, same class of network flakiness seen elsewhere tonight), unrelated to this change. The edit is a single enum-value swap within the existing `Android.Content.PM.LaunchMode` enum — no new imports, no API surface change.

## Test plan

- [ ] `dotnet build TrashMobMobile -f net10.0-android` succeeds once network is stable
- [ ] Deploy to a device (ideally OnePlus or another OEM known for aggressive task recreation)
- [ ] Background the app, relaunch by tapping the home-screen icon (not from Recents) — confirm no crash, app resumes correctly
- [ ] Confirm back-button behavior is unaffected (single-Activity Shell app, no sub-Activities to navigate through, so `SingleTask`'s back-stack change should be a no-op in practice)
- [ ] Monitor Sentry after release for recurrence of this exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)