### PR TITLE
E6: wire prod auth-domain DNS + Front Door params

### DIFF
--- a/.github/workflows/release_frontdoor-tm-pr.yml
+++ b/.github/workflows/release_frontdoor-tm-pr.yml
@@ -27,6 +27,10 @@ env:
   FRONT_DOOR_ENDPOINT: fde-tm-pr
   PRIMARY_DOMAIN: www.trashmob.eco
   APEX_DOMAIN: trashmob.eco
+  # E6 — custom auth domain for Entra External ID. Both gated together in frontDoor.bicep
+  # (enableAuthDomain); see Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6.
+  CIAM_AUTH_DOMAIN: auth.trashmob.eco
+  CIAM_TENANT_HOST: trashmobecopr.ciamlogin.com
 
 jobs:
   deploy:
@@ -70,7 +74,9 @@ jobs:
               environment=pr \
               containerAppFqdn=${{ steps.get-fqdn.outputs.fqdn }} \
               primaryDomain=${{ env.PRIMARY_DOMAIN }} \
-              apexDomain=${{ env.APEX_DOMAIN }}
+              apexDomain=${{ env.APEX_DOMAIN }} \
+              ciamAuthDomain=${{ env.CIAM_AUTH_DOMAIN }} \
+              ciamTenantHost=${{ env.CIAM_TENANT_HOST }}
 
       # Purge cached HTML/asset responses so the new bicep behavior (and any updated
       # cache-control from a same-deploy container image) takes effect immediately, not

--- a/Deploy/dnsZone.bicep
+++ b/Deploy/dnsZone.bicep
@@ -103,6 +103,14 @@ param wwwDnsAuthToken string = ''
 @description('E6: Dev Front Door managed-cert validation token for the auth-dev custom-domain. Empty skips the _dnsauth.auth-dev TXT record.')
 param authDevDnsAuthToken string = ''
 
+// E6 (prod) — same pattern as authDevDnsAuthToken above, for auth.trashmob.eco.
+// Fetch with:
+//   az afd custom-domain show --resource-group rg-trashmob-pr-westus2 \
+//     --profile-name fd-tm-pr --custom-domain-name auth-trashmob-eco \
+//     --query validationProperties.validationToken -o tsv
+@description('E6: Prod Front Door managed-cert validation token for the auth custom-domain. Empty skips the _dnsauth.auth TXT record.')
+param authDnsAuthToken string = ''
+
 // DNS Zone
 resource dnsZone 'Microsoft.Network/dnsZones@2023-07-01-preview' = {
   name: zoneName
@@ -203,6 +211,22 @@ resource authDevRecord 'Microsoft.Network/dnsZones/A@2023-07-01-preview' = {
   }
 }
 
+// E6 (prod) — auth subdomain A record, same anycast-pinning rationale as
+// authDevRecord above. Do NOT use a CNAME to the prod AFD endpoint hostname —
+// it hits the identical aadg-fleet hijack (see the long E6 comment block near
+// the params). Unconditional, same as authDevRecord.
+resource authRecord 'Microsoft.Network/dnsZones/A@2023-07-01-preview' = {
+  parent: dnsZone
+  name: 'auth'
+  properties: {
+    TTL: 300
+    ARecords: [
+      { ipv4Address: '13.107.226.70' }
+      { ipv4Address: '13.107.253.70' }
+    ]
+  }
+}
+
 // Domain validation TXT records for Front Door managed certificates.
 // Guarded by the token params — if not supplied, the resource is not
 // declared in this template and ARM Incremental will not touch any
@@ -244,6 +268,21 @@ resource dnsAuthAuthDev 'Microsoft.Network/dnsZones/TXT@2023-07-01-preview' = if
     TXTRecords: [
       {
         value: [authDevDnsAuthToken]
+      }
+    ]
+  }
+}
+
+// E6 (prod) — Front Door managed-cert validation TXT for auth.trashmob.eco.
+// Same guard pattern as dnsAuthAuthDev above.
+resource dnsAuthAuth 'Microsoft.Network/dnsZones/TXT@2023-07-01-preview' = if (authDnsAuthToken != '') {
+  parent: dnsZone
+  name: '_dnsauth.auth'
+  properties: {
+    TTL: 3600
+    TXTRecords: [
+      {
+        value: [authDnsAuthToken]
       }
     ]
   }
@@ -361,4 +400,20 @@ E6 auth-dev subdomain:
 12. In the Entra admin center on the TrashMobEcoDev tenant, add auth-dev.trashmob.eco under
     Identity > Domain names > Custom domain names (requires TXT MS=<token> verification), then
     associate it under Entra ID > Domain names > Custom URL domains.
+
+E6 auth subdomain (prod):
+13. Deploy prod Front Door via .github/workflows/release_frontdoor-tm-pr.yml with
+    ciamAuthDomain=auth.trashmob.eco and ciamTenantHost=trashmobecopr.ciamlogin.com set.
+14. Fetch the AFD custom-domain validation token:
+    az afd custom-domain show --resource-group rg-trashmob-pr-westus2 \
+      --profile-name fd-tm-pr --custom-domain-name auth-trashmob-eco \
+      --query validationProperties.validationToken -o tsv
+15. Re-run this template with authDnsAuthToken set to that value. The auth A records
+    to AFD anycast (13.107.226.70, 13.107.253.70) deploy unconditionally — no lookup needed.
+16. Wait a few minutes for the token TXT to propagate; the prod Front Door custom domain will flip from Pending -> Approved.
+17. In the Entra admin center on the TrashMobEcoPr tenant, add auth.trashmob.eco under
+    Identity > Domain names > Custom domain names (requires TXT MS=<token> verification), then
+    associate it under Entra ID > Domain names > Custom URL domains. See
+    Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md §E6 for the full task list (redirect URIs, etc.)
+    before flipping entraAuthDomain on the prod Container App workflow.
 '''

--- a/Deploy/frontDoor.bicep
+++ b/Deploy/frontDoor.bicep
@@ -412,6 +412,10 @@ DNS Configuration Required:
 2. For ${apexDomain}: Create ALIAS/ANAME record -> ${endpoint.properties.hostName}
    (Microsoft 365 DNS may not support ALIAS records - consider Azure DNS or Cloudflare)
 3. For domain validation, create TXT record: _dnsauth.${primaryDomain} with the validation token from Azure Portal
-4. (E6) If ciamAuthDomain is set: create CNAME ${ciamAuthDomain} -> ${endpoint.properties.hostName}
-        and TXT record _dnsauth.${ciamAuthDomain} with the validation token from Azure Portal
+4. (E6) If ciamAuthDomain is set: create explicit A records for ${ciamAuthDomain} pinned to
+        AFD's classic anycast pair (13.107.226.70, 13.107.253.70) — NOT a CNAME to
+        ${endpoint.properties.hostName}. A CNAME's upstream chain transits Microsoft's aadg
+        fleet and serves the wrong cert (see Deploy/dnsZone.bicep's E6 comment block for the
+        full story). Also add TXT record _dnsauth.${ciamAuthDomain} with the validation token
+        from Azure Portal.
 '''


### PR DESCRIPTION
## Summary
Step 1+2 of the prod E6 cutover (branded auth domain for Entra External ID), per `Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md` §E6. This does **not** flip user-facing auth yet — it only creates the DNS record and Front Door custom-domain infrastructure so the subsequent Entra portal association (manual, task #200) has something to point at.

- **`Deploy/dnsZone.bicep`**: adds `auth.trashmob.eco` as an explicit A record pinned to AFD's anycast pair (`13.107.226.70`, `13.107.253.70`), mirroring the existing `auth-dev` record. Deliberately **not** a CNAME to the Front Door endpoint hostname — that hits the aadg-fleet cert hijack already documented and fixed for dev (see the E6 comment block in this file). Also fixes `frontDoor.bicep`'s own printed DNS instructions, which still told operators to use a CNAME.
- **`release_frontdoor-tm-pr.yml`**: wires `ciamAuthDomain=auth.trashmob.eco` + `ciamTenantHost=trashmobecopr.ciamlogin.com` into the existing prod Front Door deploy. The CIAM origin group / route / managed-cert custom-domain resources in `frontDoor.bicep` were already merged (currently no-op since these params were never set) — this is what actually activates them.

Both bicep files validated with `az bicep build` (compile clean).

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, confirm `TrashMobProd - Front Door` workflow succeeds and creates the `og-ciam`/`route-ciam`/`auth-trashmob-eco` custom-domain resources without touching the existing `www`/apex routes
- [ ] Manually deploy `dnsZone.bicep` (no CI trigger — always manual per `Deploy/dnsZone.bicep`'s own instructions) to create the `auth` A record
- [ ] Fetch the AFD custom-domain validation token and re-deploy `dnsZone.bicep` with `authDnsAuthToken` set
- [ ] Confirm `auth.trashmob.eco`'s AFD custom domain flips from Pending → Approved
- [ ] Remaining steps (Entra portal association, redirect URIs, actual auth flip) are separate, manual, and out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)