### PR TITLE
E6: flip prod CIAM authority to auth.trashmob.eco

### DIFF
--- a/.github/workflows/release_ca-tm-pr-westus2.yml
+++ b/.github/workflows/release_ca-tm-pr-westus2.yml
@@ -39,6 +39,13 @@ env:
   APEX_DOMAIN_NAME: trashmob.eco
   APEX_MANAGED_CERTIFICATE_NAME: trashmob-eco-apex-cert
   STRAPI_CONTAINER_APP_NAME: ca-strapi-tm-pr-westus2
+  # E6 — branded auth authority for TrashMobEcoPr CIAM tenant. Backend + SPA
+  # read AzureAdEntra__Instance from the Container App; when this env var is
+  # passed to containerApp.bicep, the ternary overrides the default
+  # trashmobecopr.ciamlogin.com URL. See Planning/PRODUCTION_DEPLOYMENT_CHECKLIST.md
+  # §E6 and PR #3528. Front Door + DNS + Entra Custom URL Domain association
+  # were completed first (PR #3609 + manual Entra portal steps).
+  ENTRA_AUTH_DOMAIN: auth.trashmob.eco
 
 jobs:
   build-and-deploy:
@@ -113,6 +120,7 @@ jobs:
               managedCertificateName=${{ env.MANAGED_CERTIFICATE_NAME }} \
               apexDomainName=${{ env.APEX_DOMAIN_NAME }} \
               apexManagedCertificateName=${{ env.APEX_MANAGED_CERTIFICATE_NAME }} \
+              entraAuthDomain=${{ env.ENTRA_AUTH_DOMAIN }} \
               strapiBaseUrl="${{ steps.get-strapi.outputs.strapi_url }}"
 
       # Note: Azure AD Entra External ID configuration is set via environment variables in containerApp.bicep


### PR DESCRIPTION
## Summary
The actual production cutover for the E6 branded auth domain. Adds `entraAuthDomain=auth.trashmob.eco` to the prod Container App deploy, which flips `AzureAdEntra__Instance` (backend JWT validation + SPA MSAL authority) from `https://trashmobecopr.ciamlogin.com/` to `https://auth.trashmob.eco/` on the next deploy.

**Prerequisites already completed:**
- Front Door CIAM origin group + route + managed-cert custom domain (PR #3609) — confirmed live, existing www/apex routes verified untouched
- `auth.trashmob.eco` DNS A record pinned to AFD anycast (not a CNAME — avoids the aadg-fleet cert hijack)
- AFD custom domain validation: `Approved` / `Deployed`
- Entra admin center: domain verified (TXT added → verified → removed) and associated as a Custom URL Domain
- Redirect URIs checked on all 3 app registrations (Web SPA, API, Mobile) — confirmed none reference `ciamlogin.com`, no changes needed

**Not in scope / separate:**
- Mobile app's compile-time authority constant — needs its own app-store release
- Social IDP (Google/Apple) redirect URIs in their own consoles — per Microsoft's documented behavior, these stay on `ciamlogin.com` during the OAuth round-trip regardless of custom domain, so no change expected

## Test plan
- [ ] CI passes
- [ ] After merge, confirm prod deploy succeeds
- [ ] `curl https://www.trashmob.eco/api/v2/config` shows `authorityDomain: auth.trashmob.eco`
- [ ] Sign-in smoke test on prod: email/OTP, Google, Apple, Microsoft
- [ ] Confirm existing sessions/tokens aren't broken by the authority change

🤖 Generated with [Claude Code](https://claude.com/claude-code)