### PR TITLE
Add Cache-Control: no-store to /api/v2/config

### DIFF
--- a/TrashMob/Controllers/V2/ConfigV2Controller.cs
+++ b/TrashMob/Controllers/V2/ConfigV2Controller.cs
@@ -29,6 +29,13 @@ namespace TrashMob.Controllers.V2
         {
             logger.LogInformation("V2 GetConfig");
 
+            // Config is deploy-time data (auth authority, instrumentation key), not
+            // cacheable content. Without this, Front Door caches the response at the
+            // edge with no invalidation on deploy — different POPs can keep serving a
+            // stale authority (e.g. the old ciamlogin.com domain after an E6 auth-domain
+            // cutover) until each edge's cache independently expires.
+            Response.Headers["Cache-Control"] = "no-store, no-cache, must-revalidate";
+
             var connectionString = configuration["ApplicationInsights:ConnectionString"];
 
             // Extract instrumentation key from connection string


### PR DESCRIPTION
## Summary
- Front Door was caching `/api/v2/config` responses at the edge with no origin `Cache-Control` header, and neither deploy workflow purges it (the container-app deploy doesn't purge Front Door at all; the Front Door workflow's purge list is `/`, `/index.html`, `/assets/*` — not `/api/*`).
- Hit this live during today's prod E6 auth-domain cutover: after the deploy flipped the backend's auth authority, some users still got redirected through the old `ciamlogin.com` domain because their nearest edge POP had a cached pre-flip response. Fixed for today via a manual `az afd endpoint purge`, but the underlying gap would recur on any future config change.
- Same class of bug as the 2026-07-18 stale-`index.html` incident that led to the existing SPA `no-store` policy in `Program.cs` — this just closes the same gap for the config API.

## Test plan
- [ ] CI passes
- [ ] After deploy, confirm `curl -si .../api/v2/config` shows `cache-control: no-store, no-cache, must-revalidate` and Front Door doesn't return `x-cache: TCP_HIT` on repeated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)