### PR TITLE
E2E: match OAuth authorize path, not ciamlogin.com host

### DIFF
--- a/TrashMob/client-app/e2e/global-setup.ts
+++ b/TrashMob/client-app/e2e/global-setup.ts
@@ -39,7 +39,11 @@ async function loginAndSaveState(
         // Click Sign In
         await page.getByRole('button', { name: /sign in/i }).waitFor({ state: 'visible', timeout: 30000 });
         await page.getByRole('button', { name: /sign in/i }).click();
-        await page.waitForURL(/.*ciamlogin\.com.*/, { timeout: 15000 });
+        // Match on the OAuth authorize path rather than the host — E6 (PR #3535)
+        // flipped the authority from *.ciamlogin.com to auth-dev.trashmob.eco (dev)
+        // and will do the same for auth.trashmob.eco on prod. The `/oauth2/v2.0/authorize`
+        // path is stable across both, so this stays correct through the cutover.
+        await page.waitForURL(/\/oauth2\/v2\.0\/authorize/, { timeout: 15000 });
 
         // Step 1: Email
         await page.fill('input[name="username"]', email);


### PR DESCRIPTION
## Summary
Rebase of #3537 (opened 2026-07-29, never merged) onto current main — cherry-picked the single commit cleanly, no conflicts.

- Global E2E setup's login step hardcoded `waitForURL(/.*ciamlogin\.com.*/)`, which broke once E6 flipped the auth authority to a branded domain (`auth-dev.trashmob.eco` on dev, `auth.trashmob.eco` on prod as of today).
- This was silently masked until now because `/api/v2/config` was being cached by Front Door with no invalidation — some test runs got lucky and hit a stale cached response still pointing at `ciamlogin.com`, matching the test's assumption. #3611 (merging separately) adds `Cache-Control: no-store` to that endpoint, which makes the config always fresh — and makes this test's stale assumption fail deterministically instead of intermittently.
- Fix: match on the `/oauth2/v2.0/authorize` path instead of the host, which is stable across both the default and branded domains.

Closes out the last piece of the E6 dev/prod auth-domain rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)