### PR TITLE
Fix iOS TestFlight upload rejecting duplicate CFBundleVersion

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -12,6 +12,9 @@ on:
             build_number:
                 required: true
                 type: string
+            release_number:
+                required: true
+                type: string
             bundle_id:
                 required: true
                 type: string
@@ -69,11 +72,16 @@ jobs:
           id: version_step # step id used as reference for output values
           uses: gittools/actions/gitversion/execute@v3.2.1
 
+        # CFBundleVersion must strictly increase between TestFlight uploads. GitVersion's
+        # semVer can repeat across consecutive commits under this repo's Mainline config
+        # (see the container-tag fix in .github/actions/container-build-push/action.yml
+        # for the same class of bug) — inputs.release_number is a github.run_number-based
+        # value that always increases, mirroring build-android.yml's ApplicationVersion.
         - name: Update Build Number
-          run: sed -i '' "s|<ApplicationVersion>.*</ApplicationVersion>|<ApplicationVersion>${{ env.semVer }}</ApplicationVersion>|g" TrashMobMobile/TrashMobMobile.csproj
+          run: sed -i '' "s|<ApplicationVersion>.*</ApplicationVersion>|<ApplicationVersion>${{ inputs.release_number }}</ApplicationVersion>|g" TrashMobMobile/TrashMobMobile.csproj
 
         - name: Update Version Number
-          run: sed -i '' "s|<ApplicationDisplayVersion>.*</ApplicationDisplayVersion>|<Version>${{ env.semVer }}</Version>|g" TrashMobMobile/TrashMobMobile.csproj
+          run: sed -i '' "s|<ApplicationDisplayVersion>.*</ApplicationDisplayVersion>|<ApplicationDisplayVersion>${{ env.semVer }}</ApplicationDisplayVersion>|g" TrashMobMobile/TrashMobMobile.csproj
 
         - name: Update Bundle ID
           run: sed -i '' "s|<ApplicationId>.*</ApplicationId>|<ApplicationId>${{ inputs.bundle_id }}</ApplicationId>|g" TrashMobMobile/TrashMobMobile.csproj

--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -79,6 +79,7 @@ jobs:
       environment: test
       configuration: Release
       build_number: ${{ needs.generate-build-number.outputs.buildNumber }}
+      release_number: ${{ needs.generate-build-number.outputs.releaseNumber }}
       bundle_id: 'eco.trashmobdev.trashmobmobile'
       dotnet_version: '10.0.x'
       ios_provisioning_profile_type: 'IOS_APP_STORE'

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -76,6 +76,7 @@ jobs:
       environment: production
       configuration: Release
       build_number: ${{ needs.generate-build-number.outputs.buildNumber }}
+      release_number: ${{ needs.generate-build-number.outputs.releaseNumber }}
       bundle_id: 'eco.trashmob'
       dotnet_version: '10.0.x'
       ios_provisioning_profile_type: 'IOS_APP_STORE'


### PR DESCRIPTION
## Summary
Both prod mobile pushes today (#3609, #3610's release cuts) failed iOS TestFlight upload with:
```
The bundle version must be higher than the previously uploaded version: '2.12.2'.
```
Confirmed via CI logs that three genuinely different commits (a manual dispatch + two separate PR merges) all computed GitVersion semVer `2.12.2` — this repo's Mainline config doesn't reliably increment per-commit (same root cause as the container-tag bug fixed in `container-build-push/action.yml`, just never applied to mobile's iOS path).

- `build-ios.yml` set `<ApplicationVersion>` (→ `CFBundleVersion`) from the raw, potentially-repeating semVer.
- `build-android.yml` already avoids this — it uses `release_number` (a `github.run_number`-based value that always strictly increases) for the same field. Android has never hit this collision as a result.
- Fix: add `release_number` as an input to `build-ios.yml`, use it for `<ApplicationVersion>`, and pass it through from both callers (`main_trashmobmobileapp.yml`, `release_trashmobmobileapp.yml`), mirroring Android's existing pattern exactly.

**Also fixed a second bug** found while in this code: the "Update Version Number" step's `sed` matched `<ApplicationDisplayVersion>` but wrote a `<Version>` tag — a tag that doesn't exist anywhere in `TrashMobMobile.csproj`. This silently no-opped the display-version update on every iOS build. Fixed to write back to `<ApplicationDisplayVersion>`, matching Android's equivalent step.

## Test plan
- [ ] CI passes
- [ ] Next mobile deploy (dev or prod): confirm iOS TestFlight upload succeeds and the uploaded build's version is `release_number`, not the (possibly repeating) semVer

🤖 Generated with [Claude Code](https://claude.com/claude-code)