### PR TITLE
Update dependency @tanstack/react-table to v9 (fixed)

### DIFF
--- a/TrashMob/client-app/package-lock.json
+++ b/TrashMob/client-app/package-lock.json
@@ -34,7 +34,7 @@
                 "@radix-ui/react-tooltip": "^1.2.7",
                 "@strapi/blocks-react-renderer": "^1.0.2",
                 "@tanstack/react-query": "^5.0.0",
-                "@tanstack/react-table": "^8.21.2",
+                "@tanstack/react-table": "^9.0.0",
                 "@vis.gl/react-google-maps": "^1.5.1",
                 "@vitejs/plugin-react": "^6.0.0",
                 "axios": "^1.8.4",
@@ -6654,33 +6654,64 @@
                 "react": "^18 || ^19"
             }
         },
-        "node_modules/@tanstack/react-table": {
-            "version": "8.21.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-            "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+        "node_modules/@tanstack/react-store": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.1.tgz",
+            "integrity": "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/table-core": "8.21.3"
-            },
-            "engines": {
-                "node": ">=12"
+                "@tanstack/store": "0.11.1",
+                "use-sync-external-store": "^1.6.0"
             },
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "react": ">=16.8",
-                "react-dom": ">=16.8"
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@tanstack/react-table": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.1.2.tgz",
+            "integrity": "sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-store": "^0.11.0",
+                "@tanstack/table-core": "9.1.2"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": ">=18"
+            }
+        },
+        "node_modules/@tanstack/store": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.1.tgz",
+            "integrity": "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
             }
         },
         "node_modules/@tanstack/table-core": {
-            "version": "8.21.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.1.2.tgz",
+            "integrity": "sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==",
             "license": "MIT",
+            "dependencies": {
+                "@tanstack/store": "^0.11.0"
+            },
             "engines": {
-                "node": ">=12"
+                "node": ">=20"
             },
             "funding": {
                 "type": "github",
@@ -14168,6 +14199,15 @@
                 }
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -18178,18 +18218,36 @@
                 "@tanstack/query-devtools": "5.101.4"
             }
         },
-        "@tanstack/react-table": {
-            "version": "8.21.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
-            "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+        "@tanstack/react-store": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.11.1.tgz",
+            "integrity": "sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==",
             "requires": {
-                "@tanstack/table-core": "8.21.3"
+                "@tanstack/store": "0.11.1",
+                "use-sync-external-store": "^1.6.0"
             }
         },
+        "@tanstack/react-table": {
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-9.1.2.tgz",
+            "integrity": "sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==",
+            "requires": {
+                "@tanstack/react-store": "^0.11.0",
+                "@tanstack/table-core": "9.1.2"
+            }
+        },
+        "@tanstack/store": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.11.1.tgz",
+            "integrity": "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="
+        },
         "@tanstack/table-core": {
-            "version": "8.21.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
-            "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-9.1.2.tgz",
+            "integrity": "sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==",
+            "requires": {
+                "@tanstack/store": "^0.11.0"
+            }
         },
         "@testing-library/dom": {
             "version": "10.4.1",
@@ -23028,6 +23086,12 @@
                 "detect-node-es": "^1.1.0",
                 "tslib": "^2.0.0"
             }
+        },
+        "use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "requires": {}
         },
         "util-deprecate": {
             "version": "1.0.2",

--- a/TrashMob/client-app/package.json
+++ b/TrashMob/client-app/package.json
@@ -29,7 +29,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@strapi/blocks-react-renderer": "^1.0.2",
         "@tanstack/react-query": "^5.0.0",
-        "@tanstack/react-table": "^8.21.2",
+        "@tanstack/react-table": "^9.0.0",
         "@vis.gl/react-google-maps": "^1.5.1",
         "@vitejs/plugin-react": "^6.0.0",
         "axios": "^1.8.4",

--- a/TrashMob/client-app/src/components/ui/data-table.tsx
+++ b/TrashMob/client-app/src/components/ui/data-table.tsx
@@ -7,12 +7,34 @@ import {
     Column,
     ColumnDef,
     flexRender,
-    getCoreRowModel,
-    getFilteredRowModel,
-    getPaginationRowModel,
-    getSortedRowModel,
-    useReactTable,
+    useTable,
+    tableFeatures,
+    columnFilteringFeature,
+    rowPaginationFeature,
+    rowSortingFeature,
+    globalFilteringFeature,
+    createFilteredRowModel,
+    createPaginatedRowModel,
+    createSortedRowModel,
+    filterFns,
+    sortFns,
 } from '@tanstack/react-table';
+
+// v9 replaces the v8 pattern of passing individual `getXRowModel()` factories
+// as table options with a single `features` registry — every table in the
+// app shares this one instance so `DataTable` and every `columns.tsx` file's
+// `ColumnDef<typeof features, TData>` agree on the same feature set.
+export const features = tableFeatures({
+    columnFilteringFeature,
+    rowPaginationFeature,
+    rowSortingFeature,
+    globalFilteringFeature,
+    filteredRowModel: createFilteredRowModel(),
+    paginatedRowModel: createPaginatedRowModel(),
+    sortedRowModel: createSortedRowModel(),
+    filterFns,
+    sortFns,
+});
 
 import {
     ArrowDown,
@@ -42,7 +64,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { cn } from '@/lib/utils';
 
 interface DataTableProps<TData, TValue> {
-    columns: ColumnDef<TData, TValue>[];
+    columns: ColumnDef<typeof features, TData, TValue>[];
     data: TData[];
     /** Enable global search filter */
     enableSearch?: boolean;
@@ -66,16 +88,13 @@ export const DataTable = <TData, TValue>({
     const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
     const [globalFilter, setGlobalFilter] = useState('');
 
-    const table = useReactTable({
+    const table = useTable({
+        features,
         data,
         columns,
-        getCoreRowModel: getCoreRowModel(),
-        getPaginationRowModel: getPaginationRowModel(),
         onSortingChange: setSorting,
-        getSortedRowModel: getSortedRowModel(),
         onColumnFiltersChange: setColumnFilters,
         onGlobalFilterChange: setGlobalFilter,
-        getFilteredRowModel: getFilteredRowModel(),
         globalFilterFn: searchColumns
             ? (row, _columnId, filterValue) => {
                   const search = filterValue.toLowerCase();
@@ -167,11 +186,11 @@ export const DataTable = <TData, TValue>({
 /** Pagination */
 
 interface DataTablePaginationProps<TData> {
-    table: TanstackTable<TData>;
+    table: TanstackTable<typeof features, TData>;
 }
 
 export function DataTablePagination<TData>({ table }: DataTablePaginationProps<TData>) {
-    const { pageIndex, pageSize } = table.getState().pagination;
+    const { pageIndex, pageSize } = table.state.pagination;
     const totalFiltered = table.getFilteredRowModel().rows.length;
     const currentPageRows = table.getRowModel().rows.length;
     const firstItemNumber = pageIndex * pageSize + 1;
@@ -186,13 +205,13 @@ export function DataTablePagination<TData>({ table }: DataTablePaginationProps<T
                 <div className='flex items-center space-x-2'>
                     <p className='text-sm font-medium'>Rows per page</p>
                     <Select
-                        value={`${table.getState().pagination.pageSize}`}
+                        value={`${table.state.pagination.pageSize}`}
                         onValueChange={(value) => {
                             table.setPageSize(Number(value));
                         }}
                     >
                         <SelectTrigger className='h-8 w-[70px]'>
-                            <SelectValue placeholder={table.getState().pagination.pageSize} />
+                            <SelectValue placeholder={table.state.pagination.pageSize} />
                         </SelectTrigger>
                         <SelectContent side='top'>
                             {[10, 20, 30, 40, 50].map((pageSize) => (
@@ -204,7 +223,7 @@ export function DataTablePagination<TData>({ table }: DataTablePaginationProps<T
                     </Select>
                 </div>
                 <div className='flex w-[100px] items-center justify-center text-sm font-medium'>
-                    Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+                    Page {table.state.pagination.pageIndex + 1} of {table.getPageCount()}
                 </div>
                 <div className='flex items-center space-x-2'>
                     <Button
@@ -251,7 +270,7 @@ export function DataTablePagination<TData>({ table }: DataTablePaginationProps<T
 
 /** Column Header */
 interface DataTableColumnHeaderProps<TData, TValue> extends React.HTMLAttributes<HTMLDivElement> {
-    column: Column<TData, TValue>;
+    column: Column<typeof features, TData, TValue>;
     title: string;
 }
 

--- a/TrashMob/client-app/src/pages/MyDashboard/MyLitterReportsTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyLitterReportsTable.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router';
 import { ColumnDef } from '@tanstack/react-table';
 import { MapPin, Calendar, Eye } from 'lucide-react';
 
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import LitterReportData from '@/components/Models/LitterReportData';
@@ -28,7 +28,7 @@ const getLocation = (report: LitterReportData) => {
     return parts.join(', ') || '-';
 };
 
-const columns: ColumnDef<LitterReportData>[] = [
+const columns: ColumnDef<typeof features, LitterReportData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/MyDashboard/MyTeamsTable.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/MyTeamsTable.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router';
 import { ColumnDef } from '@tanstack/react-table';
 import { MapPin, Users, Eye, Crown } from 'lucide-react';
 
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import TeamData from '@/components/Models/TeamData';
@@ -20,7 +20,7 @@ interface MyTeamsTableProps {
 export const MyTeamsTable = ({ items, teamsILead }: MyTeamsTableProps) => {
     const leadTeamIds = new Set(teamsILead.map((t) => t.id));
 
-    const columns: ColumnDef<TeamData>[] = [
+    const columns: ColumnDef<typeof features, TeamData>[] = [
         {
             accessorKey: 'name',
             header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/MyDashboard/events-table/columns.tsx
+++ b/TrashMob/client-app/src/pages/MyDashboard/events-table/columns.tsx
@@ -3,7 +3,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import type EventData from '@/components/Models/EventData';
 import type UserData from '@/components/Models/UserData';
 import moment from 'moment';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { EventVisibilityBadge } from '@/components/ui/badge';
 import { EventActions } from './actions';
 
@@ -17,7 +17,7 @@ export const getColumns = ({
     currentUser,
     onShareEvent,
     onUnregisterEvent,
-}: GetColumnsProps): ColumnDef<EventData>[] => [
+}: GetColumnsProps): ColumnDef<typeof features, EventData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/communities/index.tsx
+++ b/TrashMob/client-app/src/pages/communities/index.tsx
@@ -7,7 +7,7 @@ import { MapPin, Building2, Eye, Map, List, Loader2 } from 'lucide-react';
 
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Card, CardContent } from '@/components/ui/card';
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { CommunitiesMap } from '@/components/communities/communities-map';
@@ -17,7 +17,7 @@ import { getLocation, getRegionTypeLabel } from '@/lib/community-utils';
 
 type ViewMode = 'list' | 'map';
 
-const columns: ColumnDef<CommunityData>[] = [
+const columns: ColumnDef<typeof features, CommunityData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Community Name' />,

--- a/TrashMob/client-app/src/pages/litterreports/index.tsx
+++ b/TrashMob/client-app/src/pages/litterreports/index.tsx
@@ -8,7 +8,7 @@ import { MapPin, Calendar, Eye, Plus, List, Map, Search } from 'lucide-react';
 
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Card, CardContent } from '@/components/ui/card';
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -76,7 +76,7 @@ const dateOptions = [
     { value: getAllCompletedTimerange(), label: 'All time' },
 ];
 
-const columns: ColumnDef<LitterReportData>[] = [
+const columns: ColumnDef<typeof features, LitterReportData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/invites/columns.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/community/invites/columns.tsx
@@ -1,12 +1,12 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { EmailInviteBatch } from '@/services/email-invites';
 import { Badge } from '@/components/ui/badge';
 import { Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router';
 
-export const getColumns = (partnerId: string): ColumnDef<EmailInviteBatch>[] => [
+export const getColumns = (partnerId: string): ColumnDef<typeof features, EmailInviteBatch>[] => [
     {
         accessorKey: 'createdDate',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Date' />,

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/documents-columns.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/documents-columns.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { DocumentExpirationBadge } from '@/components/documents/document-expiration-badge';
 import { Button } from '@/components/ui/button';
@@ -40,7 +40,7 @@ interface GetColumnsProps {
     onDelete: (documentId: string, documentName: string) => void;
 }
 
-export const getColumns = ({ onDownload, onDelete }: GetColumnsProps): ColumnDef<PartnerDocumentData>[] => [
+export const getColumns = ({ onDownload, onDelete }: GetColumnsProps): ColumnDef<typeof features, PartnerDocumentData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/documents-columns.tsx
+++ b/TrashMob/client-app/src/pages/partnerdashboard/$partnerId/documents-columns.tsx
@@ -40,7 +40,10 @@ interface GetColumnsProps {
     onDelete: (documentId: string, documentName: string) => void;
 }
 
-export const getColumns = ({ onDownload, onDelete }: GetColumnsProps): ColumnDef<typeof features, PartnerDocumentData>[] => [
+export const getColumns = ({
+    onDownload,
+    onDelete,
+}: GetColumnsProps): ColumnDef<typeof features, PartnerDocumentData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/contact-tags/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/contact-tags/columns.tsx
@@ -1,7 +1,7 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { Edit, Ellipsis, SquareX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -15,7 +15,7 @@ interface GetColumnsProps {
     onDelete: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onEdit, onDelete }: GetColumnsProps): ColumnDef<ContactTagData>[] => [
+export const getColumns = ({ onEdit, onDelete }: GetColumnsProps): ColumnDef<typeof features, ContactTagData>[] => [
     {
         accessorKey: 'color',
         header: '',

--- a/TrashMob/client-app/src/pages/siteadmin/contacts/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/contacts/columns.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { Edit, Ellipsis, Eye, SquareX } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -18,7 +18,7 @@ interface GetColumnsProps {
     onDelete: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<ContactData>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, ContactData>[] => [
     {
         accessorKey: 'lastName',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/documents/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/documents/columns.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router';
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,7 +24,7 @@ interface GetColumnsProps {
     onDownload: (documentId: string) => void;
 }
 
-export const getColumns = ({ onDownload }: GetColumnsProps): ColumnDef<AdminPartnerDocumentData>[] => [
+export const getColumns = ({ onDownload }: GetColumnsProps): ColumnDef<typeof features, AdminPartnerDocumentData>[] => [
     {
         id: 'partnerName',
         accessorFn: (row) => row.partner?.name ?? '',

--- a/TrashMob/client-app/src/pages/siteadmin/donations/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/donations/columns.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { Edit, Ellipsis, SquareX } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -29,7 +29,7 @@ interface GetColumnsProps {
     onDelete: (id: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<DonationRow>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, DonationRow>[] => [
     {
         accessorKey: 'donationDate',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Date' />,

--- a/TrashMob/client-app/src/pages/siteadmin/email-templates/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/email-templates/columns.tsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router';
 import { ColumnDef } from '@tanstack/react-table';
+import { features } from '@/components/ui/data-table';
 import EmailTemplateData from '@/components/Models/EmailTemplateData';
 
-export const columns: ColumnDef<EmailTemplateData>[] = [
+export const columns: ColumnDef<typeof features, EmailTemplateData>[] = [
     {
         accessorKey: 'name',
         header: 'Name',

--- a/TrashMob/client-app/src/pages/siteadmin/events/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/events/columns.tsx
@@ -11,9 +11,9 @@ import {
     DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 
-export const columns: ColumnDef<EventData>[] = [
+export const columns: ColumnDef<typeof features, EventData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/feedback/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/feedback/columns.tsx
@@ -39,7 +39,10 @@ const categoryLabels: Record<string, string> = {
     Praise: 'Praise',
 };
 
-export const getColumns = ({ onUpdateStatus, onDelete }: GetColumnsProps): ColumnDef<typeof features, UserFeedbackData>[] => [
+export const getColumns = ({
+    onUpdateStatus,
+    onDelete,
+}: GetColumnsProps): ColumnDef<typeof features, UserFeedbackData>[] => [
     {
         accessorKey: 'category',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Category' />,

--- a/TrashMob/client-app/src/pages/siteadmin/feedback/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/feedback/columns.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { UserFeedbackData } from '@/services/feedback';
 
 interface GetColumnsProps {
@@ -39,7 +39,7 @@ const categoryLabels: Record<string, string> = {
     Praise: 'Praise',
 };
 
-export const getColumns = ({ onUpdateStatus, onDelete }: GetColumnsProps): ColumnDef<UserFeedbackData>[] => [
+export const getColumns = ({ onUpdateStatus, onDelete }: GetColumnsProps): ColumnDef<typeof features, UserFeedbackData>[] => [
     {
         accessorKey: 'category',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Category' />,

--- a/TrashMob/client-app/src/pages/siteadmin/fundraising/engagement-columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/fundraising/engagement-columns.tsx
@@ -1,6 +1,6 @@
 import { ColumnDef } from '@tanstack/react-table';
 import { Link } from 'react-router';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { DonorLifecycleBadge, EngagementScoreBadge } from '@/components/contacts/contact-constants';
 import { type ContactEngagementScoreData } from '@/services/contacts';
 
@@ -16,7 +16,7 @@ function getLastActivity(score: ContactEngagementScoreData): string {
     return formatDate(latest);
 }
 
-export const engagementColumns: ColumnDef<ContactEngagementScoreData>[] = [
+export const engagementColumns: ColumnDef<typeof features, ContactEngagementScoreData>[] = [
     {
         accessorKey: 'contactName',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/grants/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/grants/columns.tsx
@@ -2,7 +2,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { Link } from 'react-router';
 import { Edit, Ellipsis, Eye, SquareX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -35,7 +35,7 @@ function formatAmount(min: number | null, max: number | null, awarded: number | 
     return '—';
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<GrantRow>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, GrantRow>[] => [
     {
         accessorKey: 'funderName',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Funder' />,

--- a/TrashMob/client-app/src/pages/siteadmin/grants/discovery.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/grants/discovery.tsx
@@ -9,7 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { DataTable } from '@/components/ui/data-table';
+import { DataTable, features } from '@/components/ui/data-table';
 import { useToast } from '@/hooks/use-toast';
 import { DiscoverGrants, type DiscoverGrants_Body, type DiscoveredGrantData } from '@/services/grants';
 import type { ColumnDef } from '@tanstack/react-table';
@@ -30,7 +30,7 @@ const formatAmount = (min: number | null, max: number | null) => {
     return '—';
 };
 
-const discoveredColumns: ColumnDef<DiscoveredGrantData>[] = [
+const discoveredColumns: ColumnDef<typeof features, DiscoveredGrantData>[] = [
     { accessorKey: 'funderName', header: 'Funder' },
     { accessorKey: 'programName', header: 'Program' },
     {

--- a/TrashMob/client-app/src/pages/siteadmin/invites/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/invites/columns.tsx
@@ -1,12 +1,12 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { EmailInviteBatch } from '@/services/email-invites';
 import { Badge } from '@/components/ui/badge';
 import { Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router';
 
-export const getColumns = (): ColumnDef<EmailInviteBatch>[] => [
+export const getColumns = (): ColumnDef<typeof features, EmailInviteBatch>[] => [
     {
         accessorKey: 'createdDate',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Date' />,

--- a/TrashMob/client-app/src/pages/siteadmin/job-opportunities/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/job-opportunities/columns.tsx
@@ -7,7 +7,7 @@ import {
     DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import JobOpportunityData from '@/components/Models/JobOpportunityData';
 import { Badge } from '@/components/ui/badge';
 import { Link } from 'react-router';
@@ -16,7 +16,7 @@ interface GetColumnsProps {
     onDelete: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<JobOpportunityData>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, JobOpportunityData>[] => [
     {
         accessorKey: 'title',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Title' />,

--- a/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/litter-reports/columns.tsx
@@ -11,9 +11,9 @@ import {
     DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 
-export const columns: ColumnDef<LitterReportData>[] = [
+export const columns: ColumnDef<typeof features, LitterReportData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/newsletters/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/newsletters/columns.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Newsletter } from '@/services/newsletters';
 
 interface GetColumnsProps {
@@ -33,7 +33,7 @@ export const getColumns = ({
     onSchedule,
     onTestSend,
     onDelete,
-}: GetColumnsProps): ColumnDef<Newsletter>[] => [
+}: GetColumnsProps): ColumnDef<typeof features, Newsletter>[] => [
     {
         accessorKey: 'subject',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Subject' />,

--- a/TrashMob/client-app/src/pages/siteadmin/partner-requests/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/partner-requests/columns.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router';
 import { ColumnDef } from '@tanstack/react-table';
+import { features } from '@/components/ui/data-table';
 import { Ellipsis, Eye } from 'lucide-react';
 import {
     DropdownMenu,
@@ -11,7 +12,7 @@ import { Button } from '@/components/ui/button';
 import PartnerRequestData from '@/components/Models/PartnerRequestData';
 import { PartnerRequestStatusBadge } from '@/components/partner-requests/partner-request-status-badge';
 
-export const columns: ColumnDef<PartnerRequestData>[] = [
+export const columns: ColumnDef<typeof features, PartnerRequestData>[] = [
     {
         accessorKey: 'name',
         header: 'Name',

--- a/TrashMob/client-app/src/pages/siteadmin/partners/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/partners/columns.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import PartnerData from '@/components/Models/PartnerData';
 
 interface GetColumnsProps {
@@ -33,7 +33,7 @@ const partnerStatusLabels: Record<
     3: { label: 'Pending', variant: 'outline' },
 };
 
-export const getColumns = ({ onDelete, onToggleHomePage }: GetColumnsProps): ColumnDef<PartnerData>[] => [
+export const getColumns = ({ onDelete, onToggleHomePage }: GetColumnsProps): ColumnDef<typeof features, PartnerData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/partners/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/partners/columns.tsx
@@ -33,7 +33,10 @@ const partnerStatusLabels: Record<
     3: { label: 'Pending', variant: 'outline' },
 };
 
-export const getColumns = ({ onDelete, onToggleHomePage }: GetColumnsProps): ColumnDef<typeof features, PartnerData>[] => [
+export const getColumns = ({
+    onDelete,
+    onToggleHomePage,
+}: GetColumnsProps): ColumnDef<typeof features, PartnerData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/photo-moderation/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/photo-moderation/columns.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { PhotoModerationItem, PhotoType } from '@/services/photo-moderation';
 
 interface GetColumnsProps {
@@ -46,7 +46,7 @@ export const getColumns = ({
     onDismiss,
     onViewDetails,
     tab,
-}: GetColumnsProps): ColumnDef<PhotoModerationItem>[] => [
+}: GetColumnsProps): ColumnDef<typeof features, PhotoModerationItem>[] => [
     {
         accessorKey: 'imageUrl',
         header: 'Photo',
@@ -130,7 +130,7 @@ export const getColumns = ({
                           <span className='text-muted-foreground'>-</span>
                       );
                   },
-              } as ColumnDef<PhotoModerationItem>,
+              } as ColumnDef<typeof features, PhotoModerationItem>,
           ]
         : []),
     ...(tab === 'moderated'
@@ -143,7 +143,7 @@ export const getColumns = ({
                       const statusInfo = statusColors[status] || { label: 'Unknown', color: 'bg-gray-500' };
                       return <Badge className={statusInfo.color}>{statusInfo.label}</Badge>;
                   },
-              } as ColumnDef<PhotoModerationItem>,
+              } as ColumnDef<typeof features, PhotoModerationItem>,
               {
                   accessorKey: 'moderatedDate',
                   header: 'Moderated',
@@ -151,7 +151,7 @@ export const getColumns = ({
                       const date = row.getValue('moderatedDate') as string;
                       return date ? new Date(date).toLocaleDateString() : '-';
                   },
-              } as ColumnDef<PhotoModerationItem>,
+              } as ColumnDef<typeof features, PhotoModerationItem>,
           ]
         : []),
     {

--- a/TrashMob/client-app/src/pages/siteadmin/pledges/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/pledges/columns.tsx
@@ -2,7 +2,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { Link } from 'react-router';
 import { Edit, Ellipsis, SquareX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -27,7 +27,7 @@ interface GetColumnsProps {
     onDelete: (id: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<PledgeRow>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, PledgeRow>[] => [
     {
         accessorKey: 'contactName',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Contact' />,

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/columns.tsx
@@ -10,7 +10,7 @@ import {
     DropdownMenuSeparator,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { PipelineStageBadge, PriorityBadge } from '@/components/prospects/pipeline-stage-badge';
 import CommunityProspectData from '@/components/Models/CommunityProspectData';
 
@@ -18,7 +18,7 @@ interface GetColumnsProps {
     onDelete: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<CommunityProspectData>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, CommunityProspectData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
@@ -50,7 +50,7 @@ export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<CommunityPr
         accessorKey: 'priority',
         header: 'Priority',
         cell: ({ row }) => <PriorityBadge priority={row.original.priority} />,
-        sortingFn: (a, b) => (a.original.priority ?? 99) - (b.original.priority ?? 99),
+        sortFn: (a, b) => (a.original.priority ?? 99) - (b.original.priority ?? 99),
     },
     {
         accessorKey: 'department',
@@ -95,7 +95,7 @@ export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<CommunityPr
             const days = Math.max(0, moment().diff(moment(createdDate), 'days'));
             return <span className='text-sm'>{days}</span>;
         },
-        sortingFn: (a, b) => {
+        sortFn: (a, b) => {
             const aDate = a.original.createdDate ? moment(a.original.createdDate).valueOf() : 0;
             const bDate = b.original.createdDate ? moment(b.original.createdDate).valueOf() : 0;
             // Newer prospects have HIGHER createdDate but LOWER days-in-pipeline,

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/discovery.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/discovery.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { DataTable } from '@/components/ui/data-table';
+import { DataTable, features } from '@/components/ui/data-table';
 import { useToast } from '@/hooks/use-toast';
 import {
     DiscoverProspects,
@@ -20,7 +20,7 @@ import type DiscoveredProspectData from '@/components/Models/DiscoveredProspectD
 import type GeographicGapData from '@/components/Models/GeographicGapData';
 import type { ColumnDef } from '@tanstack/react-table';
 
-const discoveredColumns: ColumnDef<DiscoveredProspectData>[] = [
+const discoveredColumns: ColumnDef<typeof features, DiscoveredProspectData>[] = [
     { accessorKey: 'name', header: 'Name' },
     { accessorKey: 'type', header: 'Type' },
     {
@@ -159,7 +159,7 @@ const GapResearchButton = ({ gap }: { gap: GeographicGapData }) => {
     );
 };
 
-const gapColumns: ColumnDef<GeographicGapData>[] = [
+const gapColumns: ColumnDef<typeof features, GeographicGapData>[] = [
     { accessorKey: 'city', header: 'City' },
     { accessorKey: 'region', header: 'Region' },
     { accessorKey: 'country', header: 'Country' },

--- a/TrashMob/client-app/src/pages/siteadmin/prospects/import.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/prospects/import.tsx
@@ -3,13 +3,13 @@ import { useMutation } from '@tanstack/react-query';
 import { Upload, Loader2, CheckCircle, AlertCircle } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { DataTable } from '@/components/ui/data-table';
+import { DataTable, features } from '@/components/ui/data-table';
 import { useToast } from '@/hooks/use-toast';
 import { ImportProspectsCsv } from '@/services/community-prospects';
 import type { CsvImportError } from '@/components/Models/CsvImportResultData';
 import type { ColumnDef } from '@tanstack/react-table';
 
-const errorColumns: ColumnDef<CsvImportError>[] = [
+const errorColumns: ColumnDef<typeof features, CsvImportError>[] = [
     { accessorKey: 'rowNumber', header: 'Row' },
     { accessorKey: 'message', header: 'Error' },
 ];

--- a/TrashMob/client-app/src/pages/siteadmin/teams/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/teams/columns.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import TeamData from '@/components/Models/TeamData';
 
 interface GetColumnsProps {
@@ -23,7 +23,7 @@ const getLocation = (team: TeamData) => {
     return parts.join(', ') || '-';
 };
 
-export const getColumns = ({ onDelete, onReactivate }: GetColumnsProps): ColumnDef<TeamData>[] => [
+export const getColumns = ({ onDelete, onReactivate }: GetColumnsProps): ColumnDef<typeof features, TeamData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/siteadmin/users/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/users/columns.tsx
@@ -8,14 +8,14 @@ import {
     DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import UserData from '@/components/Models/UserData';
 
 interface GetColumnsProps {
     onDelete: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<UserData>[] => [
+export const getColumns = ({ onDelete }: GetColumnsProps): ColumnDef<typeof features, UserData>[] => [
     {
         accessorKey: 'userName',
         header: ({ column }) => <DataTableColumnHeader column={column} title='UserName' />,

--- a/TrashMob/client-app/src/pages/siteadmin/waivers/columns.tsx
+++ b/TrashMob/client-app/src/pages/siteadmin/waivers/columns.tsx
@@ -7,7 +7,7 @@ import {
     DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
 import { Button } from '@/components/ui/button';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { WaiverVersionData, WaiverScope } from '@/components/Models/WaiverVersionData';
 import { Badge } from '@/components/ui/badge';
 import { Link } from 'react-router';
@@ -16,7 +16,7 @@ interface GetColumnsProps {
     onDeactivate: (id: string, name: string) => void;
 }
 
-export const getColumns = ({ onDeactivate }: GetColumnsProps): ColumnDef<WaiverVersionData>[] => [
+export const getColumns = ({ onDeactivate }: GetColumnsProps): ColumnDef<typeof features, WaiverVersionData>[] => [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,

--- a/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
+++ b/TrashMob/client-app/src/pages/teams/$teamId/index.tsx
@@ -21,7 +21,7 @@ import { HeroSection } from '@/components/Customization/HeroSection';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge, EventVisibilityBadge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import TeamData from '@/components/Models/TeamData';
 import TeamMemberData from '@/components/Models/TeamMemberData';
 import TeamPhotoData from '@/components/Models/TeamPhotoData';
@@ -157,7 +157,7 @@ export const TeamDetailPage = () => {
         }
     };
 
-    const memberColumns: ColumnDef<TeamMemberData>[] = [
+    const memberColumns: ColumnDef<typeof features, TeamMemberData>[] = [
         {
             accessorKey: 'userName',
             header: ({ column }) => <DataTableColumnHeader column={column} title='Name' />,
@@ -179,7 +179,7 @@ export const TeamDetailPage = () => {
         },
     ];
 
-    const eventColumns: ColumnDef<EventData>[] = [
+    const eventColumns: ColumnDef<typeof features, EventData>[] = [
         {
             accessorKey: 'name',
             header: ({ column }) => <DataTableColumnHeader column={column} title='Event' />,

--- a/TrashMob/client-app/src/pages/teams/$teamId/invites/columns.tsx
+++ b/TrashMob/client-app/src/pages/teams/$teamId/invites/columns.tsx
@@ -1,12 +1,12 @@
 import { ColumnDef } from '@tanstack/react-table';
-import { DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { EmailInviteBatch } from '@/services/email-invites';
 import { Badge } from '@/components/ui/badge';
 import { Eye } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router';
 
-export const getColumns = (teamId: string): ColumnDef<EmailInviteBatch>[] => [
+export const getColumns = (teamId: string): ColumnDef<typeof features, EmailInviteBatch>[] => [
     {
         accessorKey: 'createdDate',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Date' />,

--- a/TrashMob/client-app/src/pages/teams/index.tsx
+++ b/TrashMob/client-app/src/pages/teams/index.tsx
@@ -7,7 +7,7 @@ import { MapPin, Users, Eye, Plus, Globe, Lock, Map, List, Loader2 } from 'lucid
 
 import { HeroSection } from '@/components/Customization/HeroSection';
 import { Card, CardContent } from '@/components/ui/card';
-import { DataTable, DataTableColumnHeader } from '@/components/ui/data-table';
+import { DataTable, DataTableColumnHeader, features } from '@/components/ui/data-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TeamsMap } from '@/components/teams/teams-map';
@@ -24,7 +24,7 @@ const getLocation = (team: TeamData) => {
     return parts.join(', ') || '-';
 };
 
-const columns: ColumnDef<TeamData>[] = [
+const columns: ColumnDef<typeof features, TeamData>[] = [
     {
         accessorKey: 'name',
         header: ({ column }) => <DataTableColumnHeader column={column} title='Team Name' />,


### PR DESCRIPTION
## Summary
Supersedes #3601 (Renovate's original PR, which failed CI on this exact break) — same dependency bump, plus the actual v9 migration fix.

v9 replaced v8's pattern of passing individual `getXRowModel()` factories as table options with a required `features` registry (`tableFeatures()`), renamed `useReactTable` → `useTable`, and added a `TFeatures` generic as the first type parameter on `ColumnDef`/`Column`/`Table`.

- **`src/components/ui/data-table.tsx`**: builds and exports one shared `features` object (column filtering, row pagination, row sorting, global filtering + their row models) used by every table in the app; `useReactTable` → `useTable`; `table.getState()` → `table.state` (state system moved to TanStack Store); `Table`/`Column` type params updated.
- **`prospects/columns.tsx`**: `sortingFn` → `sortFn` (renamed column-def option), plus the `ColumnDef` generic update.
- **32 other `columns.tsx` / inline-columns files**: add `typeof features` as the new first `ColumnDef` generic argument, importing `features` from `data-table.tsx`.

No behavior change intended — same features (sort, filter, paginate, global search) still registered, just through the new plugin-registration API.

**Caveat:** I couldn't run a local build to verify compilation — this environment's npm registry access is network-restricted. This relies on the PR's own CI for real verification, same as how the original break in #3601 was caught. Worth a manual click-through of a few admin list pages (sort, filter, paginate, search) before merging, given the scope (35 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)