### PR TITLE
Fix Dockerfile Node install: copy from official image, not NodeSource

### DIFF
--- a/TrashMob/Dockerfile
+++ b/TrashMob/Dockerfile
@@ -8,9 +8,19 @@ ARG BUILD_ENVIRONMENT=pr
 
 WORKDIR /src
 
-# Install Node.js for React build
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-    && apt-get install -y nodejs
+# Install Node.js for the React build by copying the official Node.js Docker
+# image's runtime, instead of NodeSource's apt-repo installer script. That
+# script (`setup_20.x | bash`) started silently failing to add its apt repo
+# starting 2026-09-04/05 (every deploy since 22:11 UTC 2026-09-04 failed
+# identically) — `apt-get install nodejs` then fell back to Ubuntu's own
+# bundled `nodejs` package, which doesn't include npm ("npm: not found").
+# Copying straight from the official image sidesteps any apt-repo /
+# distro-packaging path entirely; kept on Node 20 to match the rest of the
+# toolchain (this is a build-time-only dependency, not a runtime one).
+COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node
+COPY --from=node:20-slim /usr/local/bin/npm /usr/local/bin/npm
+COPY --from=node:20-slim /usr/local/bin/npx /usr/local/bin/npx
+COPY --from=node:20-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 # Copy csproj files and restore dependencies
 COPY ["TrashMob/TrashMob.csproj", "TrashMob/"]

--- a/TrashMob/Dockerfile
+++ b/TrashMob/Dockerfile
@@ -17,10 +17,14 @@ WORKDIR /src
 # Copying straight from the official image sidesteps any apt-repo /
 # distro-packaging path entirely; kept on Node 20 to match the rest of the
 # toolchain (this is a build-time-only dependency, not a runtime one).
-COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node
-COPY --from=node:20-slim /usr/local/bin/npm /usr/local/bin/npm
-COPY --from=node:20-slim /usr/local/bin/npx /usr/local/bin/npx
-COPY --from=node:20-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+#
+# Copy whole directories (trailing slashes), not individual files: /usr/local/bin/npm
+# in the official image is a symlink into /usr/local/lib/node_modules/npm/bin/npm-cli.js,
+# and copying it as a single named file dereferences the symlink, dropping npm-cli.js's
+# own relative-path assumptions about where it lives (MODULE_NOT_FOUND at runtime).
+# A directory-to-directory copy preserves the symlink and everything it points to.
+COPY --from=node:20-slim /usr/local/bin/ /usr/local/bin/
+COPY --from=node:20-slim /usr/local/lib/node_modules/ /usr/local/lib/node_modules/
 
 # Copy csproj files and restore dependencies
 COPY ["TrashMob/TrashMob.csproj", "TrashMob/"]


### PR DESCRIPTION
## Summary
Every dev/prod container deploy since 2026-09-04 22:11 UTC has failed identically with \`npm: not found\`. Confirmed via 3 consecutive attempts (1 original + 2 reruns) that this is no longer transient — the last success was 22:11, everything since has failed the same way.

Root cause: the NodeSource apt-repo installer script (\`curl ... setup_20.x | bash\`) is silently failing to add its apt repo, so \`apt-get install -y nodejs\` falls back to Ubuntu's own bundled \`nodejs\` package, which doesn't ship npm.

Fix: copy \`node\`/\`npm\`/\`npx\` straight from the official \`node:20-slim\` image in a multi-stage \`COPY --from=\`, sidestepping NodeSource's apt-repo/distro-packaging path entirely. Kept on Node 20 since this is a build-time-only dependency (compiles the SPA), not a runtime one — this fixes the install *mechanism*, not an opportunistic version bump.

Confirmed no other Dockerfile in the repo uses the same NodeSource pattern (grepped for \`deb.nodesource.com\` — only this one hit).

## Test plan
- [ ] CI passes (\`build-container\` specifically, since that's what's been failing)
- [ ] After merge, confirm the next dev deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)