### PR TITLE
Fix Strapi production Docker build (missing native module build deps)

### DIFF
--- a/Strapi/Dockerfile
+++ b/Strapi/Dockerfile
@@ -23,6 +23,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
+# Install build dependencies for native modules (e.g. better-sqlite3)
+RUN apk add --no-cache python3 make g++
+
 # Install production dependencies only
 COPY package*.json ./
 RUN npm ci --omit=dev


### PR DESCRIPTION
## Why

`main`'s Strapi CMS deploy has been failing since 2026-09-12 14:55 UTC, right after Renovate PR #3602 (`better-sqlite3` v12 -> v13) merged. See the failed run: https://github.com/TrashMob-eco/TrashMob/actions/runs/34700675670

Also visible on Renovate PR #3635 (react-router-dom bump, unrelated) -- its `build-container` check fails on the exact same error, since it inherits current `main`.

## Root cause

`Strapi/Dockerfile`'s **build** stage installs `python3 make g++` before `npm ci` (line 6), but the **production** stage's `npm ci --omit=dev` (line 28) never did. This was masked as long as `better-sqlite3` had a prebuilt binary matching the `node:24-alpine` image. Once bumped to v13, node-gyp has to compile from source and fails without Python/make/g++:

```
npm error gyp ERR! find Python
npm error gyp ERR! stack Error: Could not find any Python installation to use
...
ERROR: process "/bin/sh -c npm ci --omit=dev" did not complete successfully: exit code: 1
```

## Fix

Add the same `apk add --no-cache python3 make g++` to the production stage that the build stage already has.

## Verification

Docker isn't available in my current environment to build the image locally, so this relies on CI's `build-container` check (the same check that caught the original break) to confirm the fix. Please hold off merging until that's green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
