### PR TITLE
Fix mobile geocode/weather requests failing on comma-decimal locales

### DIFF
--- a/TrashMobMobile/Services/MapRestService.cs
+++ b/TrashMobMobile/Services/MapRestService.cs
@@ -1,6 +1,7 @@
 ﻿namespace TrashMobMobile.Services;
 
 using System.Diagnostics;
+using System.Globalization;
 using Newtonsoft.Json;
 using TrashMob.Models;
 using TrashMob.Models.Extensions.V2;
@@ -13,7 +14,8 @@ public class MapRestService(IHttpClientFactory httpClientFactory) : RestServiceB
     public async Task<Address> GetAddressAsync(double latitude, double longitude,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + $"/address?latitude={latitude}&longitude={longitude}";
+        var requestUri = Controller +
+            $"/address?latitude={latitude.ToString(CultureInfo.InvariantCulture)}&longitude={longitude.ToString(CultureInfo.InvariantCulture)}";
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {

--- a/TrashMobMobile/Services/WeatherRestService.cs
+++ b/TrashMobMobile/Services/WeatherRestService.cs
@@ -1,5 +1,6 @@
 namespace TrashMobMobile.Services;
 
+using System.Globalization;
 using System.Net.Http.Json;
 using TrashMob.Models.Poco.V2;
 
@@ -12,7 +13,7 @@ public class WeatherRestService(IHttpClientFactory httpClientFactory) : RestServ
         DateTimeOffset eventDate, int durationHours, CancellationToken cancellationToken = default)
     {
         var dateParam = Uri.EscapeDataString(eventDate.ToString("o"));
-        var requestUri = $"forecast?lat={latitude}&lng={longitude}&date={dateParam}&durationHours={durationHours}";
+        var requestUri = $"forecast?lat={latitude.ToString(CultureInfo.InvariantCulture)}&lng={longitude.ToString(CultureInfo.InvariantCulture)}&date={dateParam}&durationHours={durationHours}";
 
         var httpClient = AnonymousHttpClient;
         var response = await httpClient.GetAsync(requestUri, cancellationToken);


### PR DESCRIPTION
## Why

Sentry reported a production crash (issue `4155a0990f5b410594f6ab7b029d7817`, 2026-09-12 22:19 UTC): `HttpRequestException: 400, Bad Request` from `MapRestService.GetAddressAsync`, triggered by `Step2.OnMapClicked -> CreateEventViewModel.ChangeLocation -> MapRestService.GetAddressAsync`.

## Root cause

`MapRestService.GetAddressAsync` built its query string with plain string interpolation on `latitude`/`longitude` (both `double`):

```csharp
var requestUri = Controller + $"/address?latitude={latitude}&longitude={longitude}";
```

`double.ToString()` formats using the **device's current culture**. On a locale that uses a comma as the decimal separator (much of Europe, Latin America, etc.), `45.1234` serializes as `45,1234` — producing a malformed query string. The backend's `[ApiController]` model binder can't parse `"45,1234"` as a `double`, so ASP.NET Core's automatic model-validation returns a 400 before the action method even runs. That's exactly the exception Sentry captured.

This is a known failure mode already fixed elsewhere in this codebase: `CommunityRestService.cs` and `TeamRestService.cs` both explicitly call `.ToString(CultureInfo.InvariantCulture)` on latitude/longitude before interpolating them into a URL, for this exact reason. `MapRestService.cs` never got that treatment. `WeatherRestService.cs` has the identical bug (`lat={latitude}&lng={longitude}`) — not yet reported in Sentry, but same root cause, so fixed proactively.

## Fix

Apply `.ToString(CultureInfo.InvariantCulture)` to latitude/longitude in both files, matching the established pattern.

## Verification

The MAUI Android workload isn't installed in my current environment (fresh machine, `dotnet workload restore` not yet run), so I couldn't do a full mobile build. The fix is a one-line, low-risk change using the exact same method call already compiling successfully in `CommunityRestService.cs`/`TeamRestService.cs` in this project — please do a local build/smoke test with a device set to a comma-decimal locale (e.g. German/French) before merging if you want full confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
