### PR TITLE
Merge main to release: mobile locale fix (#3647)

### DIFF
--- a/TrashMobMobile/Services/MapRestService.cs
+++ b/TrashMobMobile/Services/MapRestService.cs
@@ -1,6 +1,7 @@
 ﻿namespace TrashMobMobile.Services;
 
 using System.Diagnostics;
+using System.Globalization;
 using Newtonsoft.Json;
 using TrashMob.Models;
 using TrashMob.Models.Extensions.V2;
@@ -13,7 +14,8 @@ public class MapRestService(IHttpClientFactory httpClientFactory) : RestServiceB
     public async Task<Address> GetAddressAsync(double latitude, double longitude,
         CancellationToken cancellationToken = default)
     {
-        var requestUri = Controller + $"/address?latitude={latitude}&longitude={longitude}";
+        var requestUri = Controller +
+            $"/address?latitude={latitude.ToString(CultureInfo.InvariantCulture)}&longitude={longitude.ToString(CultureInfo.InvariantCulture)}";
 
         using (var response = await AuthorizedHttpClient.GetAsync(requestUri, cancellationToken))
         {

--- a/TrashMobMobile/Services/WeatherRestService.cs
+++ b/TrashMobMobile/Services/WeatherRestService.cs
@@ -1,5 +1,6 @@
 namespace TrashMobMobile.Services;
 
+using System.Globalization;
 using System.Net.Http.Json;
 using TrashMob.Models.Poco.V2;
 
@@ -12,7 +13,7 @@ public class WeatherRestService(IHttpClientFactory httpClientFactory) : RestServ
         DateTimeOffset eventDate, int durationHours, CancellationToken cancellationToken = default)
     {
         var dateParam = Uri.EscapeDataString(eventDate.ToString("o"));
-        var requestUri = $"forecast?lat={latitude}&lng={longitude}&date={dateParam}&durationHours={durationHours}";
+        var requestUri = $"forecast?lat={latitude.ToString(CultureInfo.InvariantCulture)}&lng={longitude.ToString(CultureInfo.InvariantCulture)}&date={dateParam}&durationHours={durationHours}";
 
         var httpClient = AnonymousHttpClient;
         var response = await httpClient.GetAsync(requestUri, cancellationToken);


### PR DESCRIPTION
Cherry-picks #3647 (fix mobile geocode/weather requests failing on comma-decimal locales) onto release.

Note: #3646 (the big main-to-release sync) was squash-merged rather than merged with a real merge commit, which breaks the ancestry release needs to recognize it already has those 124 commits. A plain 'merge main into release' now would try to reapply all of them. Cherry-picking just this one new commit avoids that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)