### PR TITLE
Fix PullRequest-Mobile.yml startup_failure (missing release_number input)

### DIFF
--- a/.github/workflows/PullRequest-Mobile.yml
+++ b/.github/workflows/PullRequest-Mobile.yml
@@ -74,6 +74,7 @@ jobs:
       environment: test
       configuration: Release
       build_number: ${{ needs.generate-build-number.outputs.buildNumber }}
+      release_number: ${{ needs.generate-build-number.outputs.releaseNumber }}
       bundle_id: 'eco.trashmobdev.trashmobmobile'
       dotnet_version: '10.0.x'
       ios_provisioning_profile_type: 'IOS_APP_STORE'


### PR DESCRIPTION
## Why

The "TrashMob Mobile App Pull Request Build" workflow (`PullRequest-Mobile.yml`) has failed with `startup_failure` — zero jobs ever scheduled — on **every single run since 2026-09-06**, across completely unrelated PRs (Renovate dependency bumps, the IFTTT removal, this session's own mobile locale fix in #3647). No mobile PR has gotten real pre-merge build coverage in over a week.

## Root cause

Confirmed via the GitHub Actions error banner: `Input release_number is required, but not provided while calling.` at `PullRequest-Mobile.yml` line 72 (the `calliOSBuild` job's `uses: ./.github/workflows/build-ios.yml`).

PR #3614 (2026-09-04, fixing a duplicate iOS TestFlight build-number bug) added `release_number` as a **required** `workflow_call` input on `build-ios.yml`, and updated `main_trashmobmobileapp.yml`'s `calliOSBuild` job to supply it. It missed the equivalent job in `PullRequest-Mobile.yml`. (`release_trashmobmobileapp.yml` already had it — only this file was missed.)

## Fix

Add the missing `release_number` input to `PullRequest-Mobile.yml`'s `calliOSBuild` job, matching `main_trashmobmobileapp.yml` exactly:
```yaml
release_number: ${{ needs.generate-build-number.outputs.releaseNumber }}
```

## Verification

This PR itself is the test — since it targets `main` and touches `TrashMobMobile/**`-adjacent workflow paths... actually it only touches the workflow file itself, which is also in the trigger's `paths` filter, so `PullRequest-Mobile.yml` should now actually run (and hopefully pass) on this PR, where it previously would have failed to even start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
