### PR TITLE
Merge main to release: cert tracker + mobile CI fix

### DIFF
--- a/.github/workflows/PullRequest-Mobile.yml
+++ b/.github/workflows/PullRequest-Mobile.yml
@@ -74,6 +74,7 @@ jobs:
       environment: test
       configuration: Release
       build_number: ${{ needs.generate-build-number.outputs.buildNumber }}
+      release_number: ${{ needs.generate-build-number.outputs.releaseNumber }}
       bundle_id: 'eco.trashmobdev.trashmobmobile'
       dotnet_version: '10.0.x'
       ios_provisioning_profile_type: 'IOS_APP_STORE'

--- a/Deploy/cert-expiry-dates.json
+++ b/Deploy/cert-expiry-dates.json
@@ -13,10 +13,16 @@
       "notes": "API keys don't expire unless revoked. Set to 2099 as placeholder. Update if you set an expiry."
     },
     {
-      "name": "Apple Sign-In Client Secret (Entra IDP)",
-      "expiryDate": "2026-08-20",
+      "name": "Apple Sign-In Client Secret (Entra IDP) - Dev",
+      "expiryDate": "2027-03-12",
       "renewUrl": "https://developer.apple.com/account/resources/authkeys/list",
-      "notes": "Apple client secrets expire every 6 months. Regenerate using d:/tools/Apple/generate-apple-secret.js"
+      "notes": "Apple client secrets expire every 6 months. Renew in the DEV Entra tenant (TrashMobEcoDev) portal: External Identities > All identity providers > Apple > re-select the .p8 key file (d:/tools/Apple/TrashMobEntraDev_AuthKey_KSP56LUPCG.p8) > Save. The file field always shows empty when reopened (browser security), and Service ID/Team ID/Key ID fields staying populated does NOT mean the secret was rotated -- you must actively re-select the file and Save to mint a fresh JWT. Rotated 2026-09-12."
+    },
+    {
+      "name": "Apple Sign-In Client Secret (Entra IDP) - Prod",
+      "expiryDate": "2027-03-12",
+      "renewUrl": "https://developer.apple.com/account/resources/authkeys/list",
+      "notes": "Apple client secrets expire every 6 months. Renew in the PROD Entra tenant (TrashMobEcoPr) portal: External Identities > All identity providers > Apple > re-select the .p8 key file (d:/tools/Apple/TrashMobEntraProd_AuthKey_535PNV2RYU.p8) > Save. Same caveats as the dev entry apply. Rotated 2026-09-12."
     },
     {
       "name": "Android Upload Keystore",


### PR DESCRIPTION
Cherry-picks the two commits merged to main since the last sync (#3646 + #3650) that release doesn't have yet:

- #3653 -- Apple Sign-In client secret rotation tracking (dev + prod), closes #3533
- #3654 -- fixes PullRequest-Mobile.yml startup_failure (missing release_number input); this workflow only targets main so it won't run against release, but keeping the file in sync avoids confusion on the next full sync

Note: release already effectively has all the content from the big #3646 sync (it was squash-merged, so ancestry doesn't show it, but the tree matches). A full 'merge main into release' would try to reapply ~127 commits unnecessarily -- these two are the only genuinely new ones, so cherry-picking directly avoids that mess (see the release-sync-must-not-squash lesson from earlier this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)