### PR TITLE
Fix GitVersion.yml never being applied (useConfigFile: true)

### DIFF
--- a/.github/actions/container-build-push/action.yml
+++ b/.github/actions/container-build-push/action.yml
@@ -60,6 +60,8 @@ runs:
     - name: Determine Version
       id: version_step
       uses: gittools/actions/gitversion/execute@v3.2.1
+      with:
+        useConfigFile: true
 
     - name: Login to Azure
       uses: azure/login@v3

--- a/.github/workflows/PullRequest-Mobile.yml
+++ b/.github/workflows/PullRequest-Mobile.yml
@@ -40,6 +40,8 @@ jobs:
       - name: Determine Version
         id: version_step # step id used as reference for output values
         uses: gittools/actions/gitversion/execute@v3.2.1
+        with:
+          useConfigFile: true
 
       - name: Set Build Number
         id: set_build_number

--- a/.github/workflows/PullRequest-WebApp.yml
+++ b/.github/workflows/PullRequest-WebApp.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Determine Version
       id: version_step
       uses: gittools/actions/gitversion/execute@v3.2.1
+      with:
+        useConfigFile: true
 
     - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
       uses: actions/setup-dotnet@v6

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -65,6 +65,8 @@ jobs:
         - name: Determine Version
           id: version_step # step id used as reference for output values
           uses: gittools/actions/gitversion/execute@v3.2.1
+          with:
+            useConfigFile: true
   
         - name: Update Build Number
           run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -71,6 +71,8 @@ jobs:
         - name: Determine Version
           id: version_step # step id used as reference for output values
           uses: gittools/actions/gitversion/execute@v3.2.1
+          with:
+            useConfigFile: true
 
         # CFBundleVersion must strictly increase between TestFlight uploads. GitVersion's
         # semVer can repeat across consecutive commits under this repo's Mainline config

--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Determine Version
         id: version_step # step id used as reference for output values
         uses: gittools/actions/gitversion/execute@v3.2.1
+        with:
+          useConfigFile: true
 
       - name: Set Offsets
         env:

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Determine Version
         id: version_step # step id used as reference for output values
         uses: gittools/actions/gitversion/execute@v3.2.1
+        with:
+          useConfigFile: true
 
       - name: release number with offset
         env:


### PR DESCRIPTION
## Context

Investigating why iOS production TestFlight uploads have been rejected all day (marketing version stuck at `2.12.2`, which Apple already has as the approved production version), I found two separate bugs.

## Bug 1 (fixed here): `useConfigFile: false` everywhere

Every one of the 7 `gitversion/execute@v3.2.1` call sites in this repo omits `useConfigFile`, which defaults to `false`. That means `GitVersion.yml` — with its explicit Mainline mode and per-commit Patch increment for `main`/`release` — has **never actually been applied anywhere**. GitVersion has always run on its built-in defaults instead.

Verified locally with the exact GitVersion 5.12.0 CLI version CI pins: without the config, computed versions carry unwanted prerelease suffixes (e.g. `2.12.0-release.1`) instead of clean release versions. This is a real, independently-worth-fixing bug — but it turned out **not** to be the cause of the stuck-at-2.12.2 symptom (confirmed: even with the config applied locally, the same commit still computed `2.12.2`).

## Bug 2 (root cause of today's block — NOT fixed by this PR)

GitVersion's Mainline mode detects version-worthy events via real 2-parent merge commits. Every "Merge main to release" sync PR in this repo's history — going back at least to 2026-07-18, not just this session — has been **squash-merged**, producing single-parent commits that are structurally invisible to GitVersion. The most recent genuine 2-parent merge commit reachable from `release` is from 2026-07-18; GitVersion has been anchored to it (and stuck) ever since.

**This shares its root cause with a previously-identified issue**: squash-merging the main→release sync PR also breaks the branch ancestry needed for future syncs to recognize what `release` already contains. Both problems go away if future "Merge main to release" PRs use "Create a merge commit" instead of squash.

**Immediate unblock (separate from this PR):** tagging `release`'s current tip as `2.13.0` moves the computed version to `2.13.2` (with this config fix) or a clean `2.13.0` (without it) — both comfortably past the Apple-imposed floor. That tag still needs to be pushed by a human (blocked here by a safety guardrail on direct tag pushes).

## Fix in this PR

Add `useConfigFile: true` to all 7 call sites:
- `build-android.yml`, `build-ios.yml`
- `main_trashmobmobileapp.yml`, `release_trashmobmobileapp.yml`, `PullRequest-Mobile.yml`
- `PullRequest-WebApp.yml`
- `.github/actions/container-build-push/action.yml` (already has a shortSha-suffix workaround for this same underlying gap — this fixes the root config issue it was masking, the workaround can stay as extra insurance)

## Verification

Tested locally with GitVersion 5.12.0 (matching CI's pinned version) against real repo history on both a feature branch and a tag-pointed commit — with the config applied, feature branches get properly-labeled prerelease versions (e.g. `2.13.40-<branch>.0`) and tagged commits get clean release versions, both behaving as `GitVersion.yml` intends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
