### PR TITLE
Decouple app-store build number from GitVersion's fragile weight

### DIFF
--- a/.github/workflows/main_trashmobmobileapp.yml
+++ b/.github/workflows/main_trashmobmobileapp.yml
@@ -40,7 +40,16 @@ jobs:
       - name: Set Offsets
         env:
           NUM: ${{ github.run_number }}
-          OFFSET: ${{ steps.version_step.outputs.WeightedPreReleaseNumber }}
+          # Fixed base for the shared Android versionCode / iOS CFBundleVersion field.
+          # Both platforms require this value to strictly increase forever and never
+          # decrease -- Google Play additionally enforces a hard ceiling of 2100000000.
+          # Previously derived from GitVersion's WeightedPreReleaseNumber (a ~1.59
+          # billion value driven by GitVersion.yml's pre-release-weight), which put us
+          # at ~76% of Google's ceiling and was one config typo away from jumping past
+          # it (see GitVersion.yml history, PR #1738). This is now a plain, explicit,
+          # human-reviewable constant instead, chosen to stay above the last shipped
+          # value (1590666003) with room to spare. Do not lower this value.
+          OFFSET: 1591000000
         run: |
           GITHUB_RUN_NUMBER_WITH_OFFSET=$(($NUM+$OFFSET))
           echo "GITHUB_RUN_NUMBER_WITH_OFFSET=$(($NUM+$OFFSET))" >> $GITHUB_ENV

--- a/.github/workflows/release_trashmobmobileapp.yml
+++ b/.github/workflows/release_trashmobmobileapp.yml
@@ -38,7 +38,16 @@ jobs:
       - name: release number with offset
         env:
           NUM: ${{ github.run_number }}
-          RELEASENUM: ${{ steps.version_step.outputs.WeightedPreReleaseNumber }}
+          # Fixed base for the shared Android versionCode / iOS CFBundleVersion field.
+          # Both platforms require this value to strictly increase forever and never
+          # decrease -- Google Play additionally enforces a hard ceiling of 2100000000.
+          # Previously derived from GitVersion's WeightedPreReleaseNumber (a ~1.59
+          # billion value driven by GitVersion.yml's pre-release-weight), which put us
+          # at ~76% of Google's ceiling and was one config typo away from jumping past
+          # it (see GitVersion.yml history, PR #1738). This is now a plain, explicit,
+          # human-reviewable constant instead, chosen to stay above the last shipped
+          # value (1590665490) with room to spare. Do not lower this value.
+          RELEASENUM: 1591000000
         run: |
           echo "GITHUB_RUN_NUMBER_WITH_OFFSET=$(($NUM + $RELEASENUM))" >> $GITHUB_ENV
 

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,12 +1,12 @@
 assembly-versioning-scheme: MajorMinorPatch
 mode: Mainline
-tag-pre-release-weight: 1590665287
+tag-pre-release-weight: 0
 branches:
   main:
     regex: ^main$
     increment: Patch
     is-release-branch: true
-    pre-release-weight: 1590665287
+    pre-release-weight: 0
     source-branches: ['main']
     tracks-release-branches: false
     tag: ''
@@ -14,7 +14,7 @@ branches:
     regex: ^release$
     increment: Patch
     is-release-branch: true
-    pre-release-weight: 1590665287
+    pre-release-weight: 0
     source-branches: ['main', 'release']
     tracks-release-branches: false
     tag: ''


### PR DESCRIPTION
## Why

While unblocking today's iOS TestFlight rejection, noticed the shipped build number (`1,590,665,490`) is already **~76% of Google Play's hard, documented `versionCode` ceiling of 2,100,000,000**. Once an Android app exceeds that ceiling, it can never upload another build under that listing — permanent, unrecoverable.

The ~1.59 billion baseline comes from `GitVersion.yml`'s `pre-release-weight` config (a cryptic 10-digit constant baked into `release_number = github.run_number + WeightedPreReleaseNumber`). This repo has already hit exactly this class of mistake once: PR #1738 (Oct 2024) accidentally added an extra digit while adjusting `tag-pre-release-weight` (`1590664954` → `15906652867`, a 10x jump). That specific typo landed on the unused tag weight and never shipped, but the same mistake on the *active* weight values would instantly push the shared build number past Google's ceiling, with no CI guard to catch it.

## Fix

- `GitVersion.yml`: reset all three weight values to `0`. Verified locally this only affects GitVersion's internal prerelease numeric suffix — the actual `SemVer` (Major.Minor.Patch) is unchanged.
- `main_trashmobmobileapp.yml` / `release_trashmobmobileapp.yml`: replace `WeightedPreReleaseNumber` with a plain, explicit constant (`1591000000`) for the `release_number` offset — chosen to stay above both apps' last-shipped values (dev: `1590666003`, prod: `1590665490`).
- `PullRequest-Mobile.yml` intentionally left alone — its build number only feeds ephemeral PR validation builds that never reach an app store, so it has no monotonicity requirement.

**This does not reduce how close we are to Google's ceiling** — that distance is now permanently part of both apps' App Store/Play Store history and can never come back down. What it removes is the specific failure mode where a single mistyped digit in an obscure GitVersion field could silently jump the shared build number past that ceiling with zero warning.

## Verification

Tested locally with the GitVersion 5.12.0 CLI (matching CI's pinned version): with the new weight config, `WeightedPreReleaseNumber` computes to `0` and the marketing `SemVer` (`2.13.40` on a test branch) is identical to before the change. Confirmed the new fixed offset produces values above both apps' most recent shipped build numbers (verified via each workflow's actual run logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
